### PR TITLE
Search and filter now expanded by default if filters applied

### DIFF
--- a/sibylapp/view/utils/filtering.py
+++ b/sibylapp/view/utils/filtering.py
@@ -1,5 +1,4 @@
 import streamlit as st
-from sibylapp.compute.context import get_term
 from sibylapp.compute import context
 
 
@@ -10,18 +9,20 @@ def view():
         st.session_state["search_term"] = ""
     if "filters" not in st.session_state:
         st.session_state["filters"] = []
-    if "expanded_search_bar" not in st.session_state:
-        st.session_state["expanded_search_bar"] = False
 
     st.checkbox("Show all", key="show_more", value=st.session_state["show_more"])
 
-    exp = st.expander(
-        "Search and filter", expanded=st.session_state["expanded_search_bar"]
-    )
-    print(exp.expanded)
+    if (
+        "search_term" in st.session_state and len(st.session_state["search_term"]) > 0
+    ) or ("filters" in st.session_state and len(st.session_state["filters"]) > 0):
+        expanded = True
+    else:
+        expanded = False
+    exp = st.expander("Search and filter", expanded=expanded)
+
     with exp:
         st.session_state["search_term"] = st.text_input(
-            "Search by %s" % get_term("Feature").lower(),
+            "Search by %s" % context.get_term("Feature").lower(),
             value=st.session_state["search_term"],
         )
         st.session_state["filters"] = st.multiselect(


### PR DESCRIPTION
To avoid confusion from people forgetting they have filters applied, the search-and-filter bar is now expanded by default if any filters are applied