### PR TITLE
Adding interactivity to explore-a-feature

### DIFF
--- a/pages/3_Understand_the_Model.py
+++ b/pages/3_Understand_the_Model.py
@@ -15,7 +15,7 @@ filtering.view_filtering()
 # Compute -------------------------------------
 predictions = model.get_dataset_predictions()
 discrete = (
-    len(np.unique(len(predictions.keys()))) <= 6
+    len(np.unique(list(predictions.values()))) <= 6
 )  # todo: ensure non-numeric is discrete
 
 all_contributions = contributions.get_dataset_contributions()

--- a/pages/3_Understand_the_Model.py
+++ b/pages/3_Understand_the_Model.py
@@ -4,6 +4,7 @@ from sibylapp.view import explore_feature, feature_importance, global_contributi
 from sibylapp.compute.context import get_term
 from sibylapp.compute import model, contributions
 import extra_streamlit_components as stx
+import numpy as np
 
 
 setup.setup_page()
@@ -13,6 +14,8 @@ filtering.view_filtering()
 
 # Compute -------------------------------------
 predictions = model.get_dataset_predictions()
+discrete = len(np.unique(len(predictions.keys()))) <= 6  # todo: ensure non-numeric is discrete
+
 all_contributions = contributions.get_dataset_contributions()
 
 # Setup tabs ----------------------------------
@@ -84,5 +87,5 @@ if tab == "4":
                 filtering.process_search_on_features(features),
             )
             explore_feature.view(
-                filtered_contributions, filtered_predictions, feature
+                filtered_contributions, filtered_predictions, feature, discrete
             )

--- a/pages/3_Understand_the_Model.py
+++ b/pages/3_Understand_the_Model.py
@@ -14,7 +14,9 @@ filtering.view_filtering()
 
 # Compute -------------------------------------
 predictions = model.get_dataset_predictions()
-discrete = len(np.unique(len(predictions.keys()))) <= 6  # todo: ensure non-numeric is discrete
+discrete = (
+    len(np.unique(len(predictions.keys()))) <= 6
+)  # todo: ensure non-numeric is discrete
 
 all_contributions = contributions.get_dataset_contributions()
 

--- a/pages/3_Understand_the_Model.py
+++ b/pages/3_Understand_the_Model.py
@@ -83,10 +83,6 @@ if tab == "4":
                 "Select a %s" % get_term("feature"),
                 filtering.process_search_on_features(features),
             )
-            col1, col2 = st.columns(2)
-            with col1:
-                explore_feature.view(
-                    filtered_contributions, filtered_predictions, feature
-                )
-            with col2:
-                global_contributions.view_feature_plot(filtered_contributions, feature)
+            explore_feature.view(
+                filtered_contributions, filtered_predictions, feature
+            )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1916,6 +1916,21 @@ python-decouple = ">=3.6,<4.0"
 streamlit = ">=0.87.0"
 
 [[package]]
+name = "streamlit-plotly-events"
+version = "0.0.6"
+description = "Plotly chart component for Streamlit that also allows for events to bubble back up to Streamlit."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "streamlit-plotly-events-0.0.6.tar.gz", hash = "sha256:1fe25dbf0e5d803aeb90253be04d7b395f5bcfdf3c654f96ff3c19424e7f9582"},
+    {file = "streamlit_plotly_events-0.0.6-py3-none-any.whl", hash = "sha256:e63fbe3c6a0746fdfce20060fc45ba5cd97805505c332b27372dcbd02c2ede29"},
+]
+
+[package.dependencies]
+plotly = ">=4.14.3"
+streamlit = ">=0.63"
+
+[[package]]
 name = "tenacity"
 version = "8.2.2"
 description = "Retry code until it succeeds"
@@ -2177,4 +2192,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8, <3.11, !=3.9.7"
-content-hash = "59d9cc7a8a552ec12db81ba686858c6596440c6bb56c904d74330a007caf1ded"
+content-hash = "5c2ece6bf7aed2b8d497438c7622cd122b235af2f972124d07a8a29ba4f202f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ streamlit-aggrid = "^0.3.4.post3"
 plotly = "^5.14.1"
 extra-streamlit-components = "^0.1.56"
 inflect = "^6.0.4"
+streamlit-plotly-events = "^0.0.6"
 
 
 [build-system]

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -15,7 +15,7 @@ def pred_format_func(
 # OTHER CONFIGURATIONS ============================================================================
 BAR_LENGTH = 8  # Number of squares to use for contribution/importance bars
 MAX_ENTITIES = (
-    10  # Maximum number of entities to select from. Set this to None to use all
+    11  # Maximum number of entities to select from. Set this to None to use all
 )
 DATASET_SIZE = 1000  # Max number of entities to use for dataset-wide visualizations
 LOAD_UPFRONT = False  # If true, run heavy computations on initial load, else greedily run as needed

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -9,7 +9,7 @@ FLIP_COLORS = True  # If true, positive contributions will be red
 def pred_format_func(
     pred,
 ):  # Function to use to format the prediction values from model
-    #return format_dollar(pred)  # See pre-written options below for defaults
+    # return format_dollar(pred)  # See pre-written options below for defaults
     return format_boolean_name(pred, "failure", "normal")
 
 

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -3,13 +3,14 @@ BASE_URL = "http://localhost:3000/api/v1/"
 CERT = None
 
 # APPLICATION-SPECIFIC CONFIGURATIONS =============================================================
-FLIP_COLORS = False  # If true, positive contributions will be red
+FLIP_COLORS = True  # If true, positive contributions will be red
 
 
 def pred_format_func(
     pred,
 ):  # Function to use to format the prediction values from model
-    return format_dollar(pred)  # See pre-written options below for defaults
+    #return format_dollar(pred)  # See pre-written options below for defaults
+    return format_boolean_name(pred, "failure", "normal")
 
 
 # OTHER CONFIGURATIONS ============================================================================

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -3,14 +3,13 @@ BASE_URL = "http://localhost:3000/api/v1/"
 CERT = None
 
 # APPLICATION-SPECIFIC CONFIGURATIONS =============================================================
-FLIP_COLORS = True  # If true, positive contributions will be red
+FLIP_COLORS = False  # If true, positive contributions will be red
 
 
 def pred_format_func(
     pred,
 ):  # Function to use to format the prediction values from model
-    # return format_dollar(pred)  # See pre-written options below for defaults
-    return format_boolean_name(pred, "failure", "normal")
+    return format_dollar(pred)  # See pre-written options below for defaults
 
 
 # OTHER CONFIGURATIONS ============================================================================

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -6,6 +6,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import pandas as pd
 from streamlit_plotly_events import plotly_events
+import numpy as np
 
 
 @st.cache_data(show_spinner="Generating plot...")
@@ -19,7 +20,7 @@ def generate_feature_distribution_plot(contribution_dict, feature):
         ]
     ).squeeze()
     if pd.api.types.is_numeric_dtype(pd.to_numeric(data, errors="ignore")):
-        trace1 = go.Box(x=data, boxpoints="all", name="")
+        trace1 = go.Box(x=data, boxpoints="all", name="", marker_color="rgb(84, 31, 63)")
         fig = go.Figure(data=[trace1])
         fig.update_layout(title="Distributions for '%s'" % feature)
         return fig
@@ -34,7 +35,7 @@ def generate_feature_distribution_plot(contribution_dict, feature):
 
 
 @st.cache_data(show_spinner="Generating plot...")
-def generate_feature_plot(contributions_to_show, predictions, feature):
+def generate_feature_plot(contributions_to_show, predictions, feature, discrete=False):
     data = {
         i: contributions_to_show[i][contributions_to_show[i]["Feature"] == feature][
             ["Contribution", "Feature Value"]
@@ -60,21 +61,24 @@ def generate_feature_plot(contributions_to_show, predictions, feature):
         "Prediction": True,
         "ID": True,
     }
+    color = "Prediction" if discrete else "Prediction "
     fig = px.scatter(
         df,
         x="Value",
         y="Contribution",
-        color="Prediction ",
+        color=color,
         color_continuous_scale="Brwnyl",
-        hover_data=hover_data,
+        color_discrete_sequence=px.colors.qualitative.Bold,
+        hover_data=hover_data
     )
+    fig.update_traces(opacity=.7, marker=dict(size=10))
     return fig
 
 
-def view(contributions_to_show, predictions, feature):
+def view(contributions_to_show, predictions, feature, discrete=False):
     col1, col2 = st.columns(2)
     with col1:
-        fig1 = generate_feature_plot(contributions_to_show, predictions, feature)
+        fig1 = generate_feature_plot(contributions_to_show, predictions, feature, discrete)
         selected_index = plotly_events(fig1)
         fig2 = generate_feature_distribution_plot(contributions_to_show, feature)
         st.plotly_chart(fig2)

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -73,7 +73,7 @@ def generate_feature_plot(contributions_to_show, predictions, feature, discrete=
         color_discrete_sequence=px.colors.qualitative.Bold,
         hover_data=hover_data,
     )
-    fig.update_traces(opacity=0.7, marker=dict(size=10))
+    fig.update_traces(opacity=0.7, marker=dict(size=10, line=dict(width=.5, color="black")))
     return fig
 
 

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -26,12 +26,14 @@ def generate_feature_plot(contributions_to_show, predictions, feature):
         ],
         axis=1,
     )
+    df["ID"] = df.index
     df = df.rename(columns={"Feature Value": "Value"})
     hover_data = {
         "Contribution": ":.3f",
         "Value": True,
         "Prediction ": False,
         "Prediction": True,
+        "ID": True,
     }
     fig = px.scatter(
         df,

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -10,12 +10,37 @@ import pandas as pd
 
 @st.cache_data(show_spinner="Generating plot...")
 def generate_feature_plot(contributions_to_show, predictions, feature):
-    data = {i: contributions_to_show[i][contributions_to_show[i]["Feature"] == feature][["Contribution", "Feature Value"]].squeeze() for i in contributions_to_show}
+    data = {
+        i: contributions_to_show[i][contributions_to_show[i]["Feature"] == feature][
+            ["Contribution", "Feature Value"]
+        ].squeeze()
+        for i in contributions_to_show
+    }
     formatted_pred = {i: config.pred_format_func(predictions[i]) for i in predictions}
-    df = pd.concat([pd.DataFrame(data).T, pd.Series(predictions, name="Raw Prediction"),  pd.Series(formatted_pred, name="Prediction")], axis=1)
-    hover_data = {"Contribution": ":.3f", "Feature Value": True, "Raw Prediction": False, "Prediction": True}
-    fig = px.scatter(df, x="Feature Value", y="Contribution", color="Raw Prediction", color_continuous_scale="Brwnyl", hover_data=hover_data)
-    #fig.update_traces(hovertemplate=config.pred_format_func)
+    # Adding the space after prediction as a hack to allow two columns with the same displayed name
+    df = pd.concat(
+        [
+            pd.DataFrame(data).T,
+            pd.Series(predictions, name="Prediction "),
+            pd.Series(formatted_pred, name="Prediction"),
+        ],
+        axis=1,
+    )
+    df = df.rename(columns={"Feature Value": "Value"})
+    hover_data = {
+        "Contribution": ":.3f",
+        "Value": True,
+        "Prediction ": False,
+        "Prediction": True,
+    }
+    fig = px.scatter(
+        df,
+        x="Value",
+        y="Contribution",
+        color="Prediction ",
+        color_continuous_scale="Brwnyl",
+        hover_data=hover_data,
+    )
     st.plotly_chart(fig)
 
 

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -1,11 +1,14 @@
 import streamlit as st
 from sibylapp.compute.context import get_term
+from sibylapp.compute import contributions
 from sibylapp.view.utils import helpers
+from sibylapp.view import feature_contribution
 from sibylapp import config
 from pyreal.visualize import feature_scatter_plot
 import matplotlib.pyplot as plt
 import plotly.express as px
 import pandas as pd
+from streamlit_plotly_events import plotly_events
 
 
 @st.cache_data(show_spinner="Generating plot...")
@@ -43,11 +46,16 @@ def generate_feature_plot(contributions_to_show, predictions, feature):
         color_continuous_scale="Brwnyl",
         hover_data=hover_data,
     )
-    st.plotly_chart(fig)
+    return fig
 
 
 def view(contributions_to_show, predictions, feature):
-    generate_feature_plot(contributions_to_show, predictions, feature)
+    fig = generate_feature_plot(contributions_to_show, predictions, feature)
+    selected_index = plotly_events(fig)
+    if len(selected_index) > 0:
+        eid = list(contributions_to_show.keys())[selected_index[0]["pointIndex"]]
+        #st.write(contributions.get_contributions(eid))
+        feature_contribution.view(eid)
 
 
 def view_instructions():

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -73,7 +73,9 @@ def generate_feature_plot(contributions_to_show, predictions, feature, discrete=
         color_discrete_sequence=px.colors.qualitative.Bold,
         hover_data=hover_data,
     )
-    fig.update_traces(opacity=0.7, marker=dict(size=10, line=dict(width=.5, color="black")))
+    fig.update_traces(
+        opacity=0.7, marker=dict(size=10, line=dict(width=0.5, color="black"))
+    )
     return fig
 
 

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -20,7 +20,9 @@ def generate_feature_distribution_plot(contribution_dict, feature):
         ]
     ).squeeze()
     if pd.api.types.is_numeric_dtype(pd.to_numeric(data, errors="ignore")):
-        trace1 = go.Box(x=data, boxpoints="all", name="", marker_color="rgb(84, 31, 63)")
+        trace1 = go.Box(
+            x=data, boxpoints="all", name="", marker_color="rgb(84, 31, 63)"
+        )
         fig = go.Figure(data=[trace1])
         fig.update_layout(title="Distributions for '%s'" % feature)
         return fig
@@ -69,23 +71,29 @@ def generate_feature_plot(contributions_to_show, predictions, feature, discrete=
         color=color,
         color_continuous_scale="Brwnyl",
         color_discrete_sequence=px.colors.qualitative.Bold,
-        hover_data=hover_data
+        hover_data=hover_data,
     )
-    fig.update_traces(opacity=.7, marker=dict(size=10))
+    fig.update_traces(opacity=0.7, marker=dict(size=10))
     return fig
 
 
 def view(contributions_to_show, predictions, feature, discrete=False):
     col1, col2 = st.columns(2)
     with col1:
-        fig1 = generate_feature_plot(contributions_to_show, predictions, feature, discrete)
+        fig1 = generate_feature_plot(
+            contributions_to_show, predictions, feature, discrete
+        )
         selected_index = plotly_events(fig1)
         fig2 = generate_feature_distribution_plot(contributions_to_show, feature)
         st.plotly_chart(fig2)
     with col2:
         if len(selected_index) > 0:
             eid = list(contributions_to_show.keys())[selected_index[0]["pointIndex"]]
-            st.subheader("Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid))
+            st.subheader(
+                "Contributions for {entity} {eid}".format(
+                    entity=get_term("Entity"), eid=eid
+                )
+            )
             feature_contribution.view(eid)
         else:
             st.warning("Select a point in the plot to see all contributions!")

--- a/sibylapp/view/feature_contribution.py
+++ b/sibylapp/view/feature_contribution.py
@@ -3,7 +3,8 @@ from sibylapp.view.utils import helpers
 from sibylapp.compute import contributions
 from sibylapp.compute.context import get_term
 from sibylapp.config import FLIP_COLORS
-from st_aggrid import AgGrid
+from st_aggrid import AgGrid, ColumnsAutoSizeMode
+from st_aggrid.grid_options_builder import GridOptionsBuilder
 
 
 def show_table(df):
@@ -12,8 +13,10 @@ def show_table(df):
             "Contribution": get_term("Contribution"),
             "Feature": get_term("Feature"),
         }
-    )
-    AgGrid(df, fit_columns_on_grid_load=True)
+    ).reset_index()
+    gb = GridOptionsBuilder.from_dataframe(df)
+    gb.configure_pagination(enabled=True, paginationAutoPageSize=False, paginationPageSize=10)
+    AgGrid(df, fit_columns_on_grid_load=True, gridOptions=gb.build(), columns_auto_size_mode=ColumnsAutoSizeMode.FIT_CONTENTS)
 
 
 @st.cache_data(show_spinner=False)

--- a/sibylapp/view/feature_contribution.py
+++ b/sibylapp/view/feature_contribution.py
@@ -8,15 +8,26 @@ from st_aggrid.grid_options_builder import GridOptionsBuilder
 
 
 def show_table(df):
-    df = df.drop("Contribution Value", axis="columns").rename(
-        columns={
-            "Contribution": get_term("Contribution"),
-            "Feature": get_term("Feature"),
-        }
-    ).reset_index()
+    df = (
+        df.drop("Contribution Value", axis="columns")
+        .rename(
+            columns={
+                "Contribution": get_term("Contribution"),
+                "Feature": get_term("Feature"),
+            }
+        )
+        .reset_index()
+    )
     gb = GridOptionsBuilder.from_dataframe(df)
-    gb.configure_pagination(enabled=True, paginationAutoPageSize=False, paginationPageSize=10)
-    AgGrid(df, fit_columns_on_grid_load=True, gridOptions=gb.build(), columns_auto_size_mode=ColumnsAutoSizeMode.FIT_CONTENTS)
+    gb.configure_pagination(
+        enabled=True, paginationAutoPageSize=False, paginationPageSize=10
+    )
+    AgGrid(
+        df,
+        fit_columns_on_grid_load=True,
+        gridOptions=gb.build(),
+        columns_auto_size_mode=ColumnsAutoSizeMode.FIT_CONTENTS,
+    )
 
 
 @st.cache_data(show_spinner=False)

--- a/sibylapp/view/feature_contribution.py
+++ b/sibylapp/view/feature_contribution.py
@@ -36,7 +36,7 @@ def format_contributions_to_view(contribution_df):
 
 
 def view(eid):
-    to_show = format_contributions_to_view(contributions.get_contributions(eid)[eid])
+    to_show = format_contributions_to_view(contributions.get_contributions([eid])[eid])
     sort_by = st.selectbox(
         "Sort order", ["Absolute", "Ascending", "Descending", "Side-by-side"]
     )

--- a/sibylapp/view/feature_importance.py
+++ b/sibylapp/view/feature_importance.py
@@ -4,7 +4,6 @@ import sibylapp.view.utils.filtering
 from sibylapp.compute import importance
 from sibylapp.view.utils import helpers
 from sibylapp.compute.context import get_term
-from st_aggrid import AgGrid
 
 
 @st.cache_data
@@ -24,21 +23,11 @@ def format_importance_to_view(importance_df):
     return importance_df
 
 
-def show_table(df):
-    df = df.drop("Importance Value", axis="columns").rename(
-        columns={
-            "Importance": get_term("Importance"),
-            "Feature": get_term("Feature"),
-        }
-    )
-    AgGrid(df, fit_columns_on_grid_load=True)
-
-
 def view():
     to_show = format_importance_to_view(importance.compute_importance())
     to_show = to_show.sort_values(by="Importance Value", axis="index", ascending=False)
     to_show = sibylapp.view.utils.filtering.process_options(to_show)
-    show_table(to_show)
+    helpers.show_table(to_show.drop("Importance Value", axis="columns"))
     return to_show["Feature"]
 
 

--- a/sibylapp/view/global_contributions.py
+++ b/sibylapp/view/global_contributions.py
@@ -8,8 +8,6 @@ from sibylapp.view.utils.helpers import (
 )
 from sibylapp.compute.context import get_term
 from st_aggrid import AgGrid
-import plotly.graph_objects as go
-import plotly.express as px
 from pyreal.visualize import swarm_plot
 import matplotlib.pyplot as plt
 from sibylapp.config import FLIP_COLORS
@@ -21,43 +19,10 @@ def generate_swarm_plot(contribution_dict):
     return plt.gcf()
 
 
-@st.cache_data(show_spinner="Generating plot...")
-def generate_feature_plot(feature, contribution_dict):
-    data = pd.DataFrame(
-        [
-            contribution_dict[eid][contribution_dict[eid]["Feature"] == feature][
-                "Feature Value"
-            ]
-            for eid in contribution_dict
-        ]
-    ).squeeze()
-    if pd.api.types.is_numeric_dtype(pd.to_numeric(data, errors="ignore")):
-        trace1 = go.Box(x=data, boxpoints="all", name="")
-        fig = go.Figure(data=[trace1])
-        fig.update_layout(title="Distributions for '%s'" % feature)
-        return fig
-    else:
-        fig = px.pie(
-            data,
-            values=data.value_counts().values,
-            names=data.value_counts().index,
-            title="Distributions for '%s'" % feature,
-        )
-        return fig
-
-
 def view_summary_plot(contributions):
     st.pyplot(
         generate_swarm_plot(rename_for_pyreal_vis(contributions)),
         clear_figure=True,
-    )
-
-
-def view_feature_plot(contributions_to_show, feature):
-    st.plotly_chart(
-        generate_feature_plot(feature, contributions_to_show),
-        clear_figure=True,
-        use_container_width=True,
     )
 
 

--- a/sibylapp/view/global_contributions.py
+++ b/sibylapp/view/global_contributions.py
@@ -1,13 +1,8 @@
 import pandas as pd
 import streamlit as st
 from sibylapp.compute import contributions
-from sibylapp.view.utils.helpers import (
-    generate_bars_bidirectional,
-    process_options,
-    rename_for_pyreal_vis,
-)
+from sibylapp.view.utils import helpers
 from sibylapp.compute.context import get_term
-from st_aggrid import AgGrid
 from pyreal.visualize import swarm_plot
 import matplotlib.pyplot as plt
 from sibylapp.config import FLIP_COLORS
@@ -21,7 +16,7 @@ def generate_swarm_plot(contribution_dict):
 
 def view_summary_plot(contributions):
     st.pyplot(
-        generate_swarm_plot(rename_for_pyreal_vis(contributions)),
+        generate_swarm_plot(helpers.rename_for_pyreal_vis(contributions)),
         clear_figure=True,
     )
 
@@ -32,7 +27,7 @@ def view(all_contributions):
     )
 
     global_contributions = contributions.compute_global_contributions(all_contributions)
-    bars = generate_bars_bidirectional(
+    bars = helpers.generate_bars_bidirectional(
         global_contributions["negative"], global_contributions["positive"]
     )
     feature_info = all_contributions[next(iter(all_contributions))][
@@ -51,8 +46,8 @@ def view(all_contributions):
     if sort_by == "Most Decreasing":
         to_show = to_show.sort_values(by="negative", axis="index")
 
-    to_show = process_options(to_show).drop(["positive", "negative"], axis=1)
-    AgGrid(to_show, fit_columns_on_grid_load=True)
+    to_show = helpers.process_options(to_show).drop(["positive", "negative"], axis=1)
+    helpers.show_table(to_show)
     return to_show
 
 

--- a/sibylapp/view/similar_entities.py
+++ b/sibylapp/view/similar_entities.py
@@ -1,6 +1,7 @@
 from sibylapp.compute import example_based, context
 from sibylapp.compute.context import get_term
 from sibylapp.view.utils.filtering import process_options
+from sibylapp.view.utils import helpers
 from st_aggrid import AgGrid, ColumnsAutoSizeMode
 from st_aggrid.shared import JsCode
 from st_aggrid.grid_options_builder import GridOptionsBuilder
@@ -70,12 +71,7 @@ def view(eid):
     for neighbor_name in neighbor_names:
         gb.configure_column(neighbor_name, cellStyle=highlight_different_jscode)
 
-    AgGrid(
-        to_show,
-        fit_columns_on_grid_load=True,
-        gridOptions=gb.build(),
-        allow_unsafe_jscode=True,
-    )
+    helpers.show_table(to_show, gb, allow_unsafe=True)
 
 
 def view_instructions():

--- a/sibylapp/view/utils/helpers.py
+++ b/sibylapp/view/utils/helpers.py
@@ -3,6 +3,8 @@ from sibylapp.config import BAR_LENGTH, FLIP_COLORS
 from sibylapp.compute.context import get_term
 import math
 import pandas as pd
+from st_aggrid import AgGrid, ColumnsAutoSizeMode
+from st_aggrid.grid_options_builder import GridOptionsBuilder
 
 from sibylapp.view.utils.filtering import process_options
 
@@ -17,6 +19,26 @@ BLANK_EM = "⬜"
 UP_ARROW = "⬆"
 DOWN_ARROW = "⬇"
 DIVIDING_BAR = "|"
+
+
+def show_table(df, gb=None, allow_unsafe=False):
+    renames = {}
+    for column in df:
+        renames[column] = get_term(column)
+    df = df.rename(columns=renames)
+    if gb is None:
+        gb = GridOptionsBuilder.from_dataframe(df)
+    if df.shape[0] > 10:
+        gb.configure_pagination(
+            enabled=True, paginationAutoPageSize=False, paginationPageSize=10
+        )
+    AgGrid(
+        df,
+        fit_columns_on_grid_load=True,
+        gridOptions=gb.build(),
+        columns_auto_size_mode=ColumnsAutoSizeMode.FIT_CONTENTS,
+        allow_unsafe_jscode=allow_unsafe
+    )
 
 
 def generate_bars(values, neutral=False):
@@ -73,38 +95,6 @@ def generate_bars_bidirectional(neg_values, pos_values):
         for (neg, pos) in zip(neg_num_to_show, pos_num_to_show)
     ]
     return pd.Series(strings, index=neg_values.index, name="Average Contribution")
-
-
-def show_sorted_contributions(to_show, sort_by, show_func, selected=None):
-    if sort_by == "Side-by-side":
-        col1, col2 = st.columns(2)
-        with col1:
-            st.subheader(get_term("Negative"))
-            to_show_neg = to_show[to_show["Contribution Value"] < 0].sort_values(
-                by="Contribution", axis="index", ascending=False
-            )
-            to_show_neg = process_options(to_show_neg)
-            show_func(to_show_neg)
-        with col2:
-            st.subheader(get_term("Positive"))
-            to_show_pos = to_show[to_show["Contribution Value"] >= 0].sort_values(
-                by="Contribution", axis="index", ascending=False
-            )
-            to_show_pos = process_options(to_show_pos)
-            show_func(to_show_pos)
-    else:
-        if sort_by == "Absolute":
-            to_show = to_show.reindex(
-                to_show["Contribution Value"].abs().sort_values(ascending=False).index
-            )
-        if sort_by == "Ascending":
-            to_show = to_show.sort_values(by="Contribution Value", axis="index")
-        if sort_by == "Descending":
-            to_show = to_show.sort_values(
-                by="Contribution Value", axis="index", ascending=False
-            )
-        to_show = process_options(to_show)
-        show_func(to_show)
 
 
 def rename_for_pyreal_vis(df):

--- a/sibylapp/view/utils/helpers.py
+++ b/sibylapp/view/utils/helpers.py
@@ -37,7 +37,7 @@ def show_table(df, gb=None, allow_unsafe=False):
         fit_columns_on_grid_load=True,
         gridOptions=gb.build(),
         columns_auto_size_mode=ColumnsAutoSizeMode.FIT_CONTENTS,
-        allow_unsafe_jscode=allow_unsafe
+        allow_unsafe_jscode=allow_unsafe,
     )
 
 

--- a/sibylapp/view/utils/helpers.py
+++ b/sibylapp/view/utils/helpers.py
@@ -75,7 +75,7 @@ def generate_bars_bidirectional(neg_values, pos_values):
     return pd.Series(strings, index=neg_values.index, name="Average Contribution")
 
 
-def show_sorted_contributions(to_show, sort_by, show_func):
+def show_sorted_contributions(to_show, sort_by, show_func, selected=None):
     if sort_by == "Side-by-side":
         col1, col2 = st.columns(2)
         with col1:


### PR DESCRIPTION
The "explore a feature" plot is now interactive, with hover capabilities. Clicking a point in the feature plot will open up the corresponding feature contributions table for that entity.

Known issues:
1. The feature being inspected should be highlighted in the table that pops up, but aggrid's pre-selected row functionality is currently broken (will be fixed once https://github.com/PablocFonseca/streamlit-aggrid/pull/221 merges). Tracked by #32
2. When switching between predictions, especially for categorical prediction types, the colors in the plot will switch for the same prediction (ie, normal and failure will both be purple when shown individually). This will be fixed in a future PR once this page's functionality is finalized. Tracked by #33 
3. Sometimes, if points are very dense, a different one will be selected than the user may expect. This is difficult to solve but can be mitigated by zooming in