### PR TITLE
legend does not change based on data selection

### DIFF
--- a/pages/3_Understand_the_Model.py
+++ b/pages/3_Understand_the_Model.py
@@ -89,5 +89,5 @@ if tab == "4":
                 filtering.process_search_on_features(features),
             )
             explore_feature.view(
-                filtered_contributions, filtered_predictions, feature, discrete
+                filtered_contributions, predictions, feature, discrete
             )

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -66,6 +66,7 @@ def generate_feature_plot(contributions_to_show, predictions, feature, discrete=
         y="Contribution",
         color=color,
         color_continuous_scale="Brwnyl",
+        category_orders={color: sorted(set(df["Prediction"]))},
         color_discrete_sequence=px.colors.qualitative.Bold,
         hover_data=hover_data,
     )

--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -66,7 +66,7 @@ def generate_feature_plot(contributions_to_show, predictions, feature, discrete=
         y="Contribution",
         color=color,
         color_continuous_scale="Brwnyl",
-        category_orders={color: sorted(set(df["Prediction"]))},
+        category_orders={color: sorted(set(df[color]))},
         color_discrete_sequence=px.colors.qualitative.Bold,
         hover_data=hover_data,
     )


### PR DESCRIPTION
### Closing issues

Closes #33 

### Description

Previously, colored contribution bars and legends in the explore-a-feature plot would be dependent on the predictions selected. This PR fixes this issue, by passing in all predictions to the explore-a-feature plot regardless of whether they are selected, then sorting legend categories to make sure colors are consistent.

### Test Plan

After starting up the frontend and backend, go to Understand the Model -> Explore a Feature. Then select/deselect predictions, or use the slider.

Examples for continuous data (using the housing dataset):

<img width="637" alt="Screen Shot 2023-07-18 at 3 24 40 PM" src="https://github.com/sibyl-dev/sibylapp2/assets/84747331/4e7e325c-680d-44f6-9655-9113c1aa1734">
<img width="637" alt="Screen Shot 2023-07-18 at 3 26 40 PM" src="https://github.com/sibyl-dev/sibylapp2/assets/84747331/980b7f36-9763-423e-b074-6dea0e582661">
<img width="639" alt="Screen Shot 2023-07-18 at 3 27 01 PM" src="https://github.com/sibyl-dev/sibylapp2/assets/84747331/74d64ae5-061d-4e68-8f9f-a67dfb41795c">