### PR TITLE
Fixing page count bug

### DIFF
--- a/sibylapp/view/explore_feature.py
+++ b/sibylapp/view/explore_feature.py
@@ -97,7 +97,7 @@ def view(eids, predictions, feature, discrete=False):
             st.subheader(
                 "Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid)
             )
-            feature_contribution.view(eid, save_space=True)
+            feature_contribution.view(eid, save_space=True, key="explore_feature")
         else:
             st.warning("Select a point in the plot to see all contributions!")
 

--- a/sibylapp/view/feature_contribution.py
+++ b/sibylapp/view/feature_contribution.py
@@ -24,7 +24,7 @@ def show_legend():
     )
 
 
-def show_sorted_contributions(to_show, sort_by):
+def show_sorted_contributions(to_show, sort_by, key=None):
     show_legend()
 
     if sort_by == "Side-by-side":
@@ -35,14 +35,14 @@ def show_sorted_contributions(to_show, sort_by):
                 by="Contribution", axis="index", ascending=False
             )
             to_show_neg = filtering.process_options(to_show_neg)
-            helpers.show_table(to_show_neg.drop("Contribution Value", axis="columns"), key="neg")
+            helpers.show_table(to_show_neg.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_neg"))
         with col2:
             st.subheader(get_term("Positive"))
             to_show_pos = to_show[to_show["Contribution Value"] >= 0].sort_values(
                 by="Contribution", axis="index", ascending=False
             )
             to_show_pos = filtering.process_options(to_show_pos)
-            helpers.show_table(to_show_pos.drop("Contribution Value", axis="columns"), key="pos")
+            helpers.show_table(to_show_pos.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_pos"))
     else:
         if sort_by == "Absolute":
             to_show = to_show.reindex(
@@ -53,7 +53,7 @@ def show_sorted_contributions(to_show, sort_by):
         if sort_by == "Descending":
             to_show = to_show.sort_values(by="Contribution Value", axis="index", ascending=False)
         to_show = filtering.process_options(to_show)
-        helpers.show_table(to_show.drop("Contribution Value", axis="columns"))
+        helpers.show_table(to_show.drop("Contribution Value", axis="columns"), key=key)
 
 
 def format_contributions_to_view(contribution_df, show_number=False):
@@ -74,7 +74,7 @@ def format_contributions_to_view(contribution_df, show_number=False):
     return contribution_df
 
 
-def view(eid, save_space=False):
+def view(eid, save_space=False, key=None):
     show_number = False
     show_average = False
     if not save_space:
@@ -105,7 +105,7 @@ def view(eid, save_space=False):
     if not show_average:
         to_show = to_show.drop("Average/Mode Value", axis="columns")
 
-    show_sorted_contributions(to_show, sort_by)
+    show_sorted_contributions(to_show, sort_by, key=key)
 
 
 def view_instructions():

--- a/sibylapp/view/feature_contribution.py
+++ b/sibylapp/view/feature_contribution.py
@@ -35,14 +35,18 @@ def show_sorted_contributions(to_show, sort_by, key=None):
                 by="Contribution", axis="index", ascending=False
             )
             to_show_neg = filtering.process_options(to_show_neg)
-            helpers.show_table(to_show_neg.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_neg"))
+            helpers.show_table(
+                to_show_neg.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_neg")
+            )
         with col2:
             st.subheader(get_term("Positive"))
             to_show_pos = to_show[to_show["Contribution Value"] >= 0].sort_values(
                 by="Contribution", axis="index", ascending=False
             )
             to_show_pos = filtering.process_options(to_show_pos)
-            helpers.show_table(to_show_pos.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_pos"))
+            helpers.show_table(
+                to_show_pos.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_pos")
+            )
     else:
         if sort_by == "Absolute":
             to_show = to_show.reindex(

--- a/sibylapp/view/feature_importance.py
+++ b/sibylapp/view/feature_importance.py
@@ -25,7 +25,7 @@ def view():
     to_show = format_importance_to_view(importance.compute_importance())
     to_show = to_show.sort_values(by="Importance Value", axis="index", ascending=False)
     to_show = sibylapp.view.utils.filtering.process_options(to_show)
-    helpers.show_table(to_show.drop("Importance Value", axis="columns"))
+    helpers.show_table(to_show.drop("Importance Value", axis="columns"), key="importance")
     return to_show["Feature"]
 
 

--- a/sibylapp/view/global_contributions.py
+++ b/sibylapp/view/global_contributions.py
@@ -48,7 +48,7 @@ def view(eids):
         to_show = to_show.sort_values(by="negative", axis="index")
 
     to_show = filtering.process_options(to_show).drop(["positive", "negative"], axis=1)
-    helpers.show_table(to_show)
+    helpers.show_table(to_show, key="global")
     return to_show
 
 

--- a/sibylapp/view/similar_entities.py
+++ b/sibylapp/view/similar_entities.py
@@ -46,7 +46,7 @@ def view(eid):
     else:
         to_show = filter_different_rows(to_show, show_different, selected_col_name)
 
-    helpers.show_table(to_show)
+    helpers.show_table(to_show, "similar_entities")
 
 
 def view_instructions():

--- a/sibylapp/view/utils/filtering.py
+++ b/sibylapp/view/utils/filtering.py
@@ -64,7 +64,7 @@ def view_entity_select():
         st.session_state["eids"],
         format_func=format_func,
         index=st.session_state["select_eid_index"],
-        key="eid"
+        key="eid",
     )
     pred = predictions[st.session_state["eid"]]
     st.sidebar.metric(context.get_term("Prediction"), config.pred_format_func(pred))

--- a/sibylapp/view/utils/filtering.py
+++ b/sibylapp/view/utils/filtering.py
@@ -59,11 +59,12 @@ def view_entity_select():
     else:
         st.session_state["select_eid_index"] = 0
 
-    st.session_state["eid"] = st.sidebar.selectbox(
+    st.sidebar.selectbox(
         "Select %s" % context.get_term("Entity"),
         st.session_state["eids"],
         format_func=format_func,
         index=st.session_state["select_eid_index"],
+        key="eid"
     )
     pred = predictions[st.session_state["eid"]]
     st.sidebar.metric(context.get_term("Prediction"), config.pred_format_func(pred))

--- a/sibylapp/view/utils/helpers.py
+++ b/sibylapp/view/utils/helpers.py
@@ -34,19 +34,21 @@ def show_table(df, page_size=10, key=None):
     table = st.container()
     _, col1, col2 = st.columns((4, 1, 1))
     with col2:
+        page_size_key = "per_page_key"
         if key is not None:
-            key = "%s%s" % (key, "_per_page")
-        page_size = st.selectbox("Rows per page", [10, 25, 50], key=key)
+            page_size_key = "%s%s" % (key, "_per_page")
+        page_size = st.selectbox("Rows per page", [10, 25, 50], key=page_size_key)
     with col1:
+        page_key = "page_key"
         if key is not None:
-            key = "%s%s" % (key, "_page")
+            page_key = "%s%s" % (key, "_page")
         page = st.number_input(
             "Page",
             value=1,
             step=1,
             min_value=1,
             max_value=int(df.shape[0] / page_size) + 1,
-            key=key,
+            key=page_key,
         )
     renames = {}
     for column in df:


### PR DESCRIPTION
### Closing issues

Closes #53 

### Description

Pages in tables will now always start on page 1 correctly when switching pages, regardless of changes made to other pages.

While I'm in the code, this PR also makes a small one-liner fix to entity selection that prevents users from having to double-select entities (same fix as in #43)

### Test Plan

Navigate to feature importance (or any other page with a table) -> change the table page -> notice all other tables correctly start on page 1
