### PR TITLE
Add option to display probability for predictions

### DIFF
--- a/1_Explore_a_Prediction.py
+++ b/1_Explore_a_Prediction.py
@@ -10,8 +10,8 @@ from sibylapp.view.utils import filtering, formatting, setup
 setup.setup_page()
 
 # Sidebar ------------------------------------
-filtering.view_entity_select()
 formatting.show_probability_select_box()
+filtering.view_entity_select()
 feature_contribution.view_instructions()
 
 # Global options ------------------------------

--- a/1_Explore_a_Prediction.py
+++ b/1_Explore_a_Prediction.py
@@ -5,12 +5,13 @@ import streamlit as st
 
 from sibylapp.compute.context import get_term
 from sibylapp.view import feature_contribution
-from sibylapp.view.utils import filtering, setup
+from sibylapp.view.utils import filtering, formatting, setup
 
 setup.setup_page()
 
 # Sidebar ------------------------------------
 filtering.view_entity_select()
+formatting.show_probability_select_box()
 feature_contribution.view_instructions()
 
 # Global options ------------------------------

--- a/pages/3_Compare_Cases.py
+++ b/pages/3_Compare_Cases.py
@@ -5,7 +5,7 @@ import streamlit as st
 
 from sibylapp.compute.context import get_term
 from sibylapp.view import entity_difference
-from sibylapp.view.utils import filtering, setup
+from sibylapp.view.utils import filtering, formatting, setup
 
 setup.setup_page(return_row_ids=True)
 
@@ -42,10 +42,12 @@ if tab == "1":
         filtering.view_time_select(
             eid, row_ids, row_id_text="row_id_comp", prefix="second", default=1
         )
+        formatting.show_probability_select_box()
         entity_difference.view_instructions(use_row_ids=True)
 elif tab == "2":
     filtering.view_entity_select(eid_text="eid", prefix="first", default=0)
     filtering.view_entity_select(eid_text="eid_comp", prefix="second", default=1)
+    formatting.show_probability_select_box()
     entity_difference.view_instructions()
 
 # Global options ------------------------------

--- a/pages/3_Compare_Cases.py
+++ b/pages/3_Compare_Cases.py
@@ -28,6 +28,7 @@ tab = stx.tab_bar(
 
 
 # Sidebar ------------------------------------
+formatting.show_probability_select_box()
 if tab == "1":
     filtering.view_entity_select(add_prediction=False)
     eid = st.session_state["eid"]
@@ -42,12 +43,10 @@ if tab == "1":
         filtering.view_time_select(
             eid, row_ids, row_id_text="row_id_comp", prefix="second", default=1
         )
-        formatting.show_probability_select_box()
         entity_difference.view_instructions(use_row_ids=True)
 elif tab == "2":
     filtering.view_entity_select(eid_text="eid", prefix="first", default=0)
     filtering.view_entity_select(eid_text="eid_comp", prefix="second", default=1)
-    formatting.show_probability_select_box()
     entity_difference.view_instructions()
 
 # Global options ------------------------------

--- a/pages/4_Experiment_with_Changes.py
+++ b/pages/4_Experiment_with_Changes.py
@@ -12,8 +12,8 @@ setup.generate_options_for_features(
     st.session_state["dataset_eids"], st.session_state["all_features"]
 )
 # Sidebar ------------------------------------
-filtering.view_entity_select()
 formatting.show_probability_select_box()
+filtering.view_entity_select()
 customized_entity.view_instructions()
 
 # Global options ------------------------------

--- a/pages/4_Experiment_with_Changes.py
+++ b/pages/4_Experiment_with_Changes.py
@@ -5,7 +5,7 @@ import copy
 import streamlit as st
 
 from sibylapp.view import customized_entity
-from sibylapp.view.utils import filtering, setup
+from sibylapp.view.utils import filtering, formatting, setup
 
 setup.setup_page()
 setup.generate_options_for_features(
@@ -13,6 +13,7 @@ setup.generate_options_for_features(
 )
 # Sidebar ------------------------------------
 filtering.view_entity_select()
+formatting.show_probability_select_box()
 customized_entity.view_instructions()
 
 # Global options ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ disable = ["missing-docstring",
           "no-else-return",
           "unspecified-encoding",
           "too-many-arguments",
-          "too-many-locals"]
+          "too-many-locals",
+          "too-many-branches",]
 [tool.pylint.BASIC]
 good-names = ["x", "y", "X", "df"]

--- a/sibylapp/compute/api.py
+++ b/sibylapp/compute/api.py
@@ -53,14 +53,24 @@ def fetch_eids(return_row_ids=False):
         return [entry["eid"] for entry in entities]
 
 
-def fetch_modified_prediction(eid, changes):
-    json = {"eid": eid, "model_id": fetch_model_id(), "changes": changes}
+def fetch_modified_prediction(eid, changes, return_proba=False):
+    json = {
+        "eid": eid,
+        "model_id": fetch_model_id(),
+        "changes": changes,
+        "return_proba": return_proba,
+    }
     prediction = api_post("modified_prediction/", json)["prediction"]
     return prediction
 
 
-def fetch_predictions(eids, row_ids=None):
-    json = {"eids": eids, "model_id": fetch_model_id(), "row_ids": row_ids}
+def fetch_predictions(eids, row_ids=None, return_proba=False):
+    json = {
+        "eids": eids,
+        "model_id": fetch_model_id(),
+        "row_ids": row_ids,
+        "return_proba": return_proba,
+    }
     predictions = api_post("multi_prediction/", json)["predictions"]
     return predictions
 

--- a/sibylapp/compute/api.py
+++ b/sibylapp/compute/api.py
@@ -35,7 +35,7 @@ def api_post(url, json):
 
 
 def fetch_model_id():
-    model_id = api_get("models/")["models"][0]["id"]
+    model_id = api_get("models/")["models"][0]["model_id"]
     return model_id
 
 

--- a/sibylapp/compute/model.py
+++ b/sibylapp/compute/model.py
@@ -3,45 +3,25 @@ import streamlit as st
 from sibylapp.compute import api, entities
 
 
-@st.cache_data(show_spinner="Computing model predictions...")
-def compute_predictions(eids):
-    predictions = api.fetch_predictions(eids)
-    if "predictions" not in st.session_state:
-        st.session_state["predictions"] = predictions
-    else:
-        st.session_state["predictions"] = dict(st.session_state["predictions"], **predictions)
+@st.cache_data(show_spinner="Getting model predictions...")
+def get_predictions(eids, return_proba=False):
+    predictions = api.fetch_predictions(eids, return_proba=return_proba)
     return predictions
 
 
-@st.cache_data(show_spinner="Getting predictions...")
-def get_predictions(eids):
-    if "predictions" not in st.session_state:
-        predictions = compute_predictions(eids)
-    else:
-        predictions = st.session_state["predictions"]
-    missing_eids = list(set(eids) - predictions.keys())
-    if len(missing_eids) > 0:
-        predictions = {**predictions, **compute_predictions(missing_eids)}
-    return {eid: predictions[eid] for eid in eids}
-
-
-@st.cache_data(show_spinner="Getting predictions...")
-def get_predictions_for_rows(eid, row_ids):
-    if "predictions_rows" not in st.session_state:
-        predictions = api.fetch_predictions([eid], row_ids)
-    else:
-        predictions = st.session_state["predictions_rows"]
+@st.cache_data(show_spinner="Getting model predictions...")
+def get_predictions_for_rows(eid, row_ids, return_proba=False):
+    predictions = api.fetch_predictions([eid], row_ids, return_proba=return_proba)
     return predictions
 
 
-@st.cache_data(show_spinner="Getting contributions...")
-def get_dataset_predictions():
+@st.cache_data(show_spinner="Getting model predictions...")
+def get_dataset_predictions(return_proba=False):
     if "dataset_eids" not in st.session_state:
         st.session_state["dataset_eids"] = entities.get_eids(1000)
-    return get_predictions(st.session_state["dataset_eids"])
+    return get_predictions(st.session_state["dataset_eids"], return_proba)
 
 
 @st.cache_data(show_spinner="Getting predictions for your data...")
-def get_modified_prediction(eid, changes):
-    st.session_state["modified_prediction"] = api.fetch_modified_prediction(eid, changes)
-    return st.session_state["modified_prediction"]
+def get_modified_prediction(eid, changes, return_proba=False):
+    return api.fetch_modified_prediction(eid, changes, return_proba=return_proba)

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -42,13 +42,15 @@ def to_pred_type(str_pred_type):
 
 FLIP_COLORS = get_config("FLIP_COLORS", "model_pred_bad_outcome", False)
 PREDICTION_TYPE = to_pred_type(get_config("PREDICTION_TYPE", "pred_type", "numeric"))
-POSITIVE_TERM = get_config("POSITIVE_TERM", "pos_pred_name", True)
-NEGATIVE_TERM = get_config("NEGATIVE_TERM", "neg_pred_name", False)
+POSITIVE_TERM = get_config("POSITIVE_TERM", "pos_pred_name", "True")
+NEGATIVE_TERM = get_config("NEGATIVE_TERM", "neg_pred_name", "False")
 PRED_FORMAT_STRING = get_config("PRED_FORMAT_STRING", "pred_format_string", "{}")
 SUPPORT_PROBABILITY = get_config("SUPPORT_PROBABILITY", "support_probability", False)
 
 
-def pred_format_func(pred):
+def pred_format_func(pred, display_proba=False):
+    if display_proba:
+        return f"{pred*100:.1f}%"
     if cfg.get("OVERRIDE_PRED_FORMAT"):
         return manual_pred_format_func(pred)
     if PREDICTION_TYPE == PredType.NUMERIC:

--- a/sibylapp/config.py
+++ b/sibylapp/config.py
@@ -45,6 +45,7 @@ PREDICTION_TYPE = to_pred_type(get_config("PREDICTION_TYPE", "pred_type", "numer
 POSITIVE_TERM = get_config("POSITIVE_TERM", "pos_pred_name", True)
 NEGATIVE_TERM = get_config("NEGATIVE_TERM", "neg_pred_name", False)
 PRED_FORMAT_STRING = get_config("PRED_FORMAT_STRING", "pred_format_string", "{}")
+SUPPORT_PROBABILITY = get_config("SUPPORT_PROBABILITY", "support_probability", False)
 
 
 def pred_format_func(pred):

--- a/sibylapp/config.yml
+++ b/sibylapp/config.yml
@@ -15,4 +15,4 @@ POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models
 PRED_FORMAT_STRING: # fstring for formatting numeric model outputs
 OVERRIDE_PRED_FORMAT: # If True, use "config.manual_pred_format_func" to format preds, ignoring previous 3 configs
-SUPPORT_PROBABILITY: True # Only set this to True when model supports `predict_proba`
+SUPPORT_PROBABILITY: # Only set this to True when model supports `predict_proba`

--- a/sibylapp/config.yml
+++ b/sibylapp/config.yml
@@ -10,7 +10,7 @@ LOAD_UPFRONT: True # If true, run heavy computations on initial load, else greed
 
 # APPLICATION-SPECIFIC CONFIGURATIONS (overrides API context) ========================================
 FLIP_COLORS: # If true, positive contributions will be red
-PREDICTION_TYPE: "boolean" # One of "numeric", "boolean", "categorical"
+PREDICTION_TYPE: # One of "numeric", "boolean", "categorical"
 POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models
 PRED_FORMAT_STRING: # fstring for formatting numeric model outputs

--- a/sibylapp/config.yml
+++ b/sibylapp/config.yml
@@ -10,9 +10,9 @@ LOAD_UPFRONT: True # If true, run heavy computations on initial load, else greed
 
 # APPLICATION-SPECIFIC CONFIGURATIONS (overrides API context) ========================================
 FLIP_COLORS: # If true, positive contributions will be red
-PREDICTION_TYPE: # One of "numeric", "boolean", "categorical"
+PREDICTION_TYPE: "boolean" # One of "numeric", "boolean", "categorical"
 POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models
 PRED_FORMAT_STRING: # fstring for formatting numeric model outputs
 OVERRIDE_PRED_FORMAT: # If True, use "config.manual_pred_format_func" to format preds, ignoring previous 3 configs
-SUPPORT_PROBABILITY: # Only set this to True when model supports `predict_proba`
+SUPPORT_PROBABILITY: True # Only set this to True when model supports `predict_proba`

--- a/sibylapp/config.yml
+++ b/sibylapp/config.yml
@@ -15,3 +15,4 @@ POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models
 PRED_FORMAT_STRING: # fstring for formatting numeric model outputs
 OVERRIDE_PRED_FORMAT: # If True, use "config.manual_pred_format_func" to format preds, ignoring previous 3 configs
+SUPPORT_PROBABILITY: # Only set this to True when model supports `predict_proba`

--- a/sibylapp/view/customized_entity.py
+++ b/sibylapp/view/customized_entity.py
@@ -52,13 +52,20 @@ def view_feature_boxes(
 
 
 def view_prediction(eid, changes):
-    prediction = model.get_modified_prediction(eid, changes)
+    pred = model.get_modified_prediction(eid, changes)
+    if st.session_state["display_proba"]:
+        pred_proba = model.get_modified_prediction(eid, changes, return_proba=True)
+        pred_display = (
+            pred_format_func(pred) + " (" + pred_format_func(pred_proba, display_proba=True) + ")"
+        )
+    else:
+        pred_display = pred_format_func(pred)
     st.metric(
         "Model's {prediction} of modified {entity}:".format(
             prediction=get_term("Prediction", lower=True),
             entity=get_term("Entity"),
         ),
-        pred_format_func(prediction),
+        pred_display,
     )
 
 

--- a/sibylapp/view/entity_difference.py
+++ b/sibylapp/view/entity_difference.py
@@ -24,6 +24,27 @@ def view_prediction_difference(eid, eid_comp, use_row_ids=False, row_ids=None, e
     if PREDICTION_TYPE == PredType.NUMERIC:
         difference = new_prediction - old_prediction
         output_text = pred_format_func(difference)
+        if difference > 0:
+            output_text = "+" + output_text
+
+    elif st.session_state["display_proba"]:
+        if use_row_ids:
+            predictions_proba = model.get_predictions_for_rows(
+                eid_for_rows, row_ids, return_proba=True
+            )
+        else:
+            predictions_proba = model.get_predictions(st.session_state["eids"], return_proba=True)
+        old_prediction_proba = predictions_proba[eid]
+        new_prediction_proba = predictions_proba[eid_comp]
+        # Invert the probabilities if prediction is False
+        if not old_prediction:
+            old_prediction_proba = 1 - old_prediction_proba
+        if not new_prediction:
+            new_prediction_proba = 1 - new_prediction_proba
+        difference = new_prediction_proba - old_prediction_proba
+        output_text = pred_format_func(difference, display_proba=True)
+        if difference > 0:
+            output_text = "+" + output_text
 
     else:
         if pred_format_func(new_prediction) == pred_format_func(old_prediction):

--- a/sibylapp/view/entity_difference.py
+++ b/sibylapp/view/entity_difference.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 from sibylapp.compute import contributions, model
 from sibylapp.compute.context import get_term
-from sibylapp.config import PREDICTION_TYPE, PredType, pred_format_func
+from sibylapp.config import POSITIVE_TERM, PREDICTION_TYPE, PredType, pred_format_func
 from sibylapp.view.utils import filtering, helpers
 from sibylapp.view.utils.formatting import format_two_contributions_to_view
 
@@ -42,7 +42,7 @@ def view_prediction_difference(eid, eid_comp, use_row_ids=False, row_ids=None, e
         if not new_prediction:
             new_prediction_proba = 1 - new_prediction_proba
         difference = new_prediction_proba - old_prediction_proba
-        output_text = pred_format_func(difference, display_proba=True)
+        output_text = pred_format_func(difference, display_proba=True) + " " + POSITIVE_TERM
         if difference > 0:
             output_text = "+" + output_text
 

--- a/sibylapp/view/utils/filtering.py
+++ b/sibylapp/view/utils/filtering.py
@@ -56,7 +56,9 @@ def view_entity_select(eid_text="eid", prefix=None, default=0, add_prediction=Tr
             return f"{context.get_term('Entity')} {eid}"
 
     if add_prediction:
-        predictions = model.get_predictions(st.session_state["eids"])
+        predictions = model.get_predictions(
+            st.session_state["eids"], return_proba=st.session_state["display_proba"]
+        )
 
     if eid_text in st.session_state:
         st.session_state[f"select_{eid_text}_index"] = st.session_state["eids"].index(
@@ -80,6 +82,13 @@ def view_entity_select(eid_text="eid", prefix=None, default=0, add_prediction=Tr
         pred = predictions[st.session_state[eid_text]]
         st.sidebar.metric(context.get_term("Prediction"), config.pred_format_func(pred))
 
+    st.session_state["display_proba"] = st.checkbox(
+        "Show probability",
+        value=st.session_state["display_proba"],
+        help="Display prediction in terms of probability",
+        disabled=not config.SUPPORT_PROBABILITY,
+    )
+
 
 def view_time_select(eid, row_ids, row_id_text="row_id", prefix=None, default=0):
     def format_rowid_select(row_id):
@@ -100,7 +109,9 @@ def view_time_select(eid, row_ids, row_id_text="row_id", prefix=None, default=0)
         index=st.session_state[f"select_{row_id_text}_index"],
         key=row_id_text,
     )
-    predictions = model.get_predictions_for_rows(eid, row_ids)
+    predictions = model.get_predictions_for_rows(
+        eid, row_ids, return_proba=st.session_state["display_proba"]
+    )
     pred = predictions[row_id]
     st.sidebar.metric(context.get_term("Prediction"), config.pred_format_func(pred))
 

--- a/sibylapp/view/utils/filtering.py
+++ b/sibylapp/view/utils/filtering.py
@@ -107,7 +107,7 @@ def view_time_select(eid, row_ids, row_id_text="row_id", prefix=None, default=0)
     else:
         select_text = f"Select {prefix} prediction time"
 
-    row_id = st.sidebar.selectbox(
+    st.sidebar.selectbox(
         select_text,
         row_ids,
         format_func=format_rowid_select,
@@ -115,11 +115,11 @@ def view_time_select(eid, row_ids, row_id_text="row_id", prefix=None, default=0)
         key=row_id_text,
     )
     predictions = model.get_predictions_for_rows(eid, row_ids)
-    pred = predictions[row_id]
+    pred = predictions[st.session_state[row_id_text]]
 
     if st.session_state["display_proba"]:
         predictions_proba = model.get_predictions_for_rows(eid, row_ids, return_proba=True)
-        pred_proba = predictions_proba[row_id]
+        pred_proba = predictions_proba[st.session_state[row_id_text]]
         pred_display = (
             config.pred_format_func(pred)
             + " ("

--- a/sibylapp/view/utils/formatting.py
+++ b/sibylapp/view/utils/formatting.py
@@ -61,10 +61,10 @@ def format_two_contributions_to_view(
 
 
 def show_probability_select_box():
-    st.sidebar.checkbox(
-        "Show probability",
-        value=st.session_state["display_proba"],
-        help="Display prediction in terms of probability",
-        disabled=not config.SUPPORT_PROBABILITY,
-        key="display_proba",
-    )
+    if config.SUPPORT_PROBABILITY:
+        st.sidebar.checkbox(
+            "Show probability",
+            value=st.session_state["display_proba"],
+            help="Display prediction in terms of probability",
+            key="display_proba",
+        )

--- a/sibylapp/view/utils/formatting.py
+++ b/sibylapp/view/utils/formatting.py
@@ -1,3 +1,6 @@
+import streamlit as st
+
+from sibylapp import config
 from sibylapp.compute.context import get_term
 from sibylapp.view.utils import helpers
 
@@ -55,3 +58,12 @@ def format_two_contributions_to_view(
             axis="columns",
         )
     return compare_df
+
+
+def show_probability_select_box():
+    st.session_state["display_proba"] = st.sidebar.checkbox(
+        "Show probability",
+        value=st.session_state["display_proba"],
+        help="Display prediction in terms of probability",
+        disabled=not config.SUPPORT_PROBABILITY,
+    )

--- a/sibylapp/view/utils/formatting.py
+++ b/sibylapp/view/utils/formatting.py
@@ -61,9 +61,10 @@ def format_two_contributions_to_view(
 
 
 def show_probability_select_box():
-    st.session_state["display_proba"] = st.sidebar.checkbox(
+    st.sidebar.checkbox(
         "Show probability",
         value=st.session_state["display_proba"],
         help="Display prediction in terms of probability",
         disabled=not config.SUPPORT_PROBABILITY,
+        key="display_proba",
     )

--- a/sibylapp/view/utils/setup.py
+++ b/sibylapp/view/utils/setup.py
@@ -27,6 +27,9 @@ def setup_page(return_row_ids=False):
     if "all_features" not in st.session_state:
         st.session_state["all_features"] = features.get_features()
 
+    # Global display options ---------------------
+    if "display_proba" not in st.session_state:
+        st.session_state["display_proba"] = False
     # Populate cache -----------------------------
     if config.LOAD_UPFRONT:
         model.get_dataset_predictions()


### PR DESCRIPTION
Add a new option that allows binary outcomes to be presented in terms of probabilities. Pages `Explore a Prediction`, `Compare Cases`, and `Experiment with changes` are subject to this change. 

This option must be manually enabled by setting `SUPPORT_PROBABILITY` to True in the config.
