### PR TITLE
Updating sort term/strategy

### DIFF
--- a/sibylapp2/view/compare_entities.py
+++ b/sibylapp2/view/compare_entities.py
@@ -71,46 +71,39 @@ def view_prediction_difference(
         )
 
 
-def view_compare_cases_helper(save_space=False):
-    show_number = False
-    show_contribution = False
-    if not save_space:
-        cols = st.columns(2)
-        with cols[0]:
-            sort_by = helpers.show_sort_options(
-                ["Absolute Difference", "Positive Difference", "Negative Difference"]
-            )
-        with cols[1]:
-            show_number = st.checkbox(
-                "Show numeric contributions?",
-                help="Show the exact amount this feature contributes to the model prediction",
-            )
-            show_contribution = st.checkbox(
-                "Show original contributions?",
-                help="Show the original %s contributions for both %s"
-                % (get_term("Feature"), get_term("Entity", plural=True)),
-            )
-    else:
-        cols = st.columns(1)
-        with cols[0]:
-            sort_by = helpers.show_sort_options(
-                ["Absolute Difference", "Positive Difference", "Negative Difference"]
-            )
+def view_compare_cases_helper():
+    cols = st.columns(2)
+    with cols[0]:
+        sort_by = helpers.show_sort_options(
+            ["Absolute Change", f"More {get_term('Positive')}", f"More {get_term('Negative')}"]
+        )
+    with cols[1]:
+        show_number = st.checkbox(
+            "Show numeric contributions?",
+            help="Show the exact amount this feature contributes to the model prediction",
+        )
+        show_contribution = st.checkbox(
+            "Show original contributions?",
+            help="Show the original %s contributions for both %s"
+            % (get_term("Feature"), get_term("Entity", plural=True)),
+        )
     return sort_by, show_number, show_contribution
 
 
 def sort_contributions(to_show, sort_by):
     helpers.show_legend(similar_entities=True)
-    if sort_by == "Absolute Difference":
+    if sort_by == "Absolute Change":
         to_show = to_show.reindex(
             to_show["Contribution Change Value"].abs().sort_values(ascending=False).index
         )
-    if sort_by == "Positive Difference":
+    if sort_by == f"More {get_term('Positive')}":
         to_show = to_show.sort_values(
             by="Contribution Change Value", axis="index", ascending=False
         )
-    if sort_by == "Negative Difference":
+        to_show = to_show[to_show["Contribution Change Value"] > 0]
+    if sort_by == f"More {get_term('Negative')}":
         to_show = to_show.sort_values(by="Contribution Change Value", axis="index")
+        to_show = to_show[to_show["Contribution Change Value"] < 0]
 
     to_show = filtering.process_options(to_show)
     return to_show
@@ -141,13 +134,13 @@ def filter_rows(to_show, same, use_row_ids=False):
     return to_show_filtered
 
 
-def view(model_id, eid, eid_comp=None, row_id=None, row_id_comp=None, save_space=False):
+def view(model_id, eid, eid_comp=None, row_id=None, row_id_comp=None):
     """
     Either `eid_comp` or `row_id`/`row_id_comp` must be given. If `eid_comp` is given,
     compare entity `eid` to entity `eid_comp`. If the row_ids are given, compare entity `eid`'s
     `row_id` to its `row_id_comp`.
     """
-    sort_by, show_number, show_contribution = view_compare_cases_helper(save_space)
+    sort_by, show_number, show_contribution = view_compare_cases_helper()
 
     if eid_comp is None:
         if row_id is None or row_id_comp is None:

--- a/sibylapp2/view/customized_entity.py
+++ b/sibylapp2/view/customized_entity.py
@@ -108,11 +108,11 @@ def filter_different_rows(eid, to_show):
     return to_show_filtered
 
 
-def view(eid, changes, model_id, row_id=None, save_space=False):
+def view(eid, changes, model_id, row_id=None):
     """
     eid is used as `row_id` when use_row_id is True
     """
-    sort_by, show_number, show_contribution = view_compare_cases_helper(save_space=save_space)
+    sort_by, show_number, show_contribution = view_compare_cases_helper()
     if row_id is not None:
         original_contribution_df, original_values_df = contributions.get_contributions_for_rows(
             eid, [row_id], model_id=model_id

--- a/sibylapp2/view/feature_contribution.py
+++ b/sibylapp2/view/feature_contribution.py
@@ -34,10 +34,12 @@ def show_sorted_contributions(to_show, sort_by, key=None):
             to_show = to_show.reindex(
                 to_show["Contribution Value"].abs().sort_values(ascending=False).index
             )
-        if sort_by == "Ascending":
-            to_show = to_show.sort_values(by="Contribution Value", axis="index")
-        if sort_by == "Descending":
+        if sort_by == get_term("Positive"):
             to_show = to_show.sort_values(by="Contribution Value", axis="index", ascending=False)
+            to_show = to_show[to_show["Contribution Value"] > 0]
+        if sort_by == get_term("Negative"):
+            to_show = to_show.sort_values(by="Contribution Value", axis="index")
+            to_show = to_show[to_show["Contribution Value"] < 0]
         to_show = filtering.process_options(to_show)
         helpers.show_table(to_show.drop("Contribution Value", axis="columns"), key=key)
 
@@ -72,7 +74,7 @@ def view(eid, model_id, row_id=None, save_space=False, key=None):
         cols = st.columns(2)
         with cols[0]:
             sort_by = helpers.show_sort_options(
-                ["Absolute", "Ascending", "Descending", "Side-by-side"]
+                ["Absolute", get_term("Positive"), get_term("Negative"), "Side-by-side"]
             )
         with cols[1]:
             show_number = st.checkbox(
@@ -80,7 +82,9 @@ def view(eid, model_id, row_id=None, save_space=False, key=None):
                 help="Show the exact amount this feature contributes to the model prediction",
             )
     else:
-        sort_by = helpers.show_sort_options(["Absolute", "Ascending", "Descending"])
+        sort_by = helpers.show_sort_options(
+            ["Absolute", get_term("Positive"), get_term("Negative")]
+        )
 
     to_show = format_contributions_to_view(eid, model_id, row_id=row_id, show_number=show_number)
 

--- a/sibylapp2/view/global_contributions.py
+++ b/sibylapp2/view/global_contributions.py
@@ -26,7 +26,7 @@ def view_summary_plot(eids, model_id):
 
 
 def view(eids, model_id):
-    sort_by = helpers.show_sort_options(["Total", "Most Increasing", "Most Decreasing"])
+    sort_by = helpers.show_sort_options(["Total", get_term("Positive"), get_term("Negative")])
     show_legend()
 
     global_contributions = contributions.compute_global_contributions(eids, model_id)
@@ -41,10 +41,12 @@ def view(eids, model_id):
         to_show = to_show.reindex(
             (to_show["negative"].abs() + to_show["positive"]).sort_values(ascending=False).index
         )
-    if sort_by == "Most Increasing":
+    if sort_by == get_term("Positive"):
         to_show = to_show.sort_values(by="positive", axis="index", ascending=False)
-    if sort_by == "Most Decreasing":
+        to_show = to_show[to_show["positive"] > 0]
+    if sort_by == get_term("Negative"):
         to_show = to_show.sort_values(by="negative", axis="index")
+        to_show = to_show[to_show["negative"] < 0]
 
     to_show = filtering.process_options(to_show).drop(["positive", "negative"], axis=1)
     helpers.show_table(to_show, key="global")

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -43,7 +43,7 @@ def neg_em(color_scheme=None):
 
 
 def show_sort_options(options):
-    return st.radio("Sort by", options, horizontal=True)
+    return st.radio("Sort/Filter by", options, horizontal=True)
 
 
 def show_text_input_side_by_side(


### PR DESCRIPTION
### Closing issues

Closes #111 

### Description

Updates sorting terms/strategies to be more consistent. Users can now filter to show only positive features or negative features (meaning, features that contribute positively or negatively - language can be specified on configuration). All sorts of contributions now use similar terminology

### Test Plan

Ran through on a test dataset

