### PR TITLE
Support live-changing feature descriptions

### DIFF
--- a/1_Explore_a_Prediction.py
+++ b/1_Explore_a_Prediction.py
@@ -30,5 +30,8 @@ if tab == "1":
     if "row_id" in st.session_state:
         row_id = st.session_state["row_id"]
     feature_contribution.view(
-        st.session_state["eid"], st.session_state["model_id"], st.session_state["row_id"]
+        st.session_state["eid"],
+        st.session_state["model_id"],
+        key="feature_contributions",
+        row_id=st.session_state["row_id"],
     )

--- a/sibylapp2/compute/api.py
+++ b/sibylapp2/compute/api.py
@@ -50,6 +50,26 @@ def api_post(url, json=None, data=None):
     return response.json()
 
 
+def api_put(url, json=None, data=None):
+    fetch_url = cfg["BASE_URL"] + url
+    try:
+        if data:
+            response = session.put(
+                fetch_url, data=data, headers={"Content-Type": "application/json"}
+            )
+        else:
+            response = session.put(fetch_url, json=json)
+    except requests.exceptions.RequestException as err:
+        st.error(f"Connection error. Please check your connection and refresh the page ({err})")
+        st.stop()
+    if response.status_code != 200:
+        st.error(
+            "Error with request (%s) %s: %s" % (fetch_url, response.status_code, response.reason)
+        )
+        st.stop()
+    return response.json()
+
+
 def fetch_models():
     models = api_get("models/")["models"]
     return [model["model_id"] for model in models]
@@ -116,6 +136,45 @@ def fetch_features():
     )
     features_df = features_df.set_index("name")
     return features_df
+
+
+def format_feature_df_for_modify(features_df):
+    """
+    Formats a dataframe to for use in modify_features
+
+    Args:
+        features_df (DataFrame): Dataframe of features to be modified.
+            Includes the following columns (case-insensitive):
+            - [index]: Feature name
+            - Feature: Feature description
+            - Category: Feature category
+            - Type: Feature type
+    """
+    features_df["name"] = features_df.index
+    features_df.columns = features_df.columns.str.lower()
+    features_df["description"] = features_df["feature"]
+    features_df = features_df[
+        [col for col in ["name", "category", "description", "type"] if col in features_df.columns]
+    ]
+    return features_df.to_dict(orient="records")
+
+
+def modify_features(new_features):
+    """
+    Put new_features in the database.
+
+    Args:
+        new_features (dict): Dictionary of feature name to feature information, including:
+            - name (required): Feature name
+            - description: Feature description
+            - category: Feature category
+            - type: Feature type
+            - values: Feature values (if categorical)
+
+    Returns:
+        None
+    """
+    api_put("features/", json={"features": new_features})
 
 
 def fetch_entity(eid, row_id=None) -> pd.Series:

--- a/sibylapp2/compute/features.py
+++ b/sibylapp2/compute/features.py
@@ -29,3 +29,7 @@ def get_categorical_values():
     features_df = features_df[features_df["Type"] == "categorical"]
     feature_value_dict = dict(zip(features_df.index, features_df["Values"]))
     return feature_value_dict
+
+
+def get_categories():
+    return api.fetch_categories()["name"].tolist()

--- a/sibylapp2/view/compare_entities.py
+++ b/sibylapp2/view/compare_entities.py
@@ -195,7 +195,9 @@ def view(model_id, eid, eid_comp=None, row_id=None, row_id_comp=None):
         to_show = filter_rows(to_show, same=False, use_row_ids=eid_comp is None)
 
     to_show = sort_contributions(to_show, sort_by)
-    helpers.show_table(to_show.drop("Contribution Change Value", axis="columns"))
+    helpers.show_table(
+        to_show.drop("Contribution Change Value", axis="columns"), "compare_entities"
+    )
 
 
 def view_instructions(use_row_ids=False):

--- a/sibylapp2/view/customized_entity.py
+++ b/sibylapp2/view/customized_entity.py
@@ -166,6 +166,7 @@ def view(eid, changes, model_id, row_id=None):
             changes,
             columns=["%s Value for modified %s" % (get_term("Feature"), get_term("Entity"))],
         ),
+        key="experiment_with_changes",
     )
 
 

--- a/sibylapp2/view/feature_contribution.py
+++ b/sibylapp2/view/feature_contribution.py
@@ -6,7 +6,7 @@ from sibylapp2.view.utils import filtering, helpers
 from sibylapp2.view.utils.helpers import show_legend
 
 
-def show_sorted_contributions(to_show, sort_by, key=None):
+def show_sorted_contributions(to_show, sort_by, key):
     show_legend()
 
     if sort_by == "Side-by-side":
@@ -64,7 +64,7 @@ def format_contributions_to_view(eid, model_id, row_id=None, show_number=False):
     return full_df
 
 
-def view(eid, model_id, row_id=None, save_space=False, key=None):
+def view(eid, model_id, key, row_id=None, save_space=False):
     """
     `eid_for_rows` is only used when `use_row_id` == True.
     `eid` are used as row_id when `use_row_id` == True

--- a/sibylapp2/view/feature_importance.py
+++ b/sibylapp2/view/feature_importance.py
@@ -6,7 +6,6 @@ from sibylapp2.compute.context import get_term
 from sibylapp2.view.utils import helpers
 
 
-@st.cache_data
 def format_importance_to_view(importance_df):
     importance_df = importance_df.rename(
         columns={

--- a/sibylapp2/view/similar_entities.py
+++ b/sibylapp2/view/similar_entities.py
@@ -45,7 +45,6 @@ def view(eid, model_id):
         pass
     else:
         to_show = filter_different_rows(to_show, show_different, selected_col_name)
-
     helpers.show_table(to_show, "similar_entities")
 
 

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -153,8 +153,8 @@ def show_table(df, key, style_function=None, enable_editing=True):
         df = style_function(df)
 
     def update_table_with_changes():
-        if "changes_to_table" in st.session_state:
-            changes = st.session_state["changes_to_table"]["edited_rows"]
+        if "changes_to_table_%s" in st.session_state:
+            changes = st.session_state["changes_to_table_%s"]["edited_rows"]
             for row in changes:
                 for col in changes[row]:
                     row_offset = row + ((page - 1) * page_size)
@@ -169,7 +169,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
         use_container_width=True,
         num_rows="fixed",
         column_config=column_config,
-        key="changes_to_table",
+        key="changes_to_table_%s" % key,
         on_change=update_table_with_changes,
     )
 
@@ -183,7 +183,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
             format_feature_df_for_modify(st.session_state["edited_table_%s" % key].copy())
         )
         st.session_state["changes_made"] = False
-        del st.session_state["changes_to_table"]
+        del st.session_state["changes_to_table_%s" % key]
         features.get_features.clear()
 
     if enable_editing:

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -157,7 +157,10 @@ def show_table(df, key, style_function=None, enable_editing=True):
             changes = st.session_state["changes_to_table"]["edited_rows"]
             for row in changes:
                 for col in changes[row]:
-                    st.session_state["edited_table_%s" % key].iloc[row][col] = changes[row][col]
+                    row_offset = row + ((page - 1) * page_size)
+                    st.session_state["edited_table_%s" % key].iloc[row_offset][col] = changes[row][
+                        col
+                    ]
                     st.session_state["changes_made"] = True
 
     table.data_editor(
@@ -189,7 +192,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
         reset_changes_container.button(
             "Reset changes", disabled=not st.session_state["changes_made"], on_click=reset_changes
         )
-        save = save_changes_container.button(
+        save_changes_container.button(
             "Save changes to database",
             disabled=not st.session_state["changes_made"],
             on_click=save_changes,

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -153,8 +153,8 @@ def show_table(df, key, style_function=None, enable_editing=True):
         df = style_function(df)
 
     def update_table_with_changes():
-        if "changes_to_table_%s" in st.session_state:
-            changes = st.session_state["changes_to_table_%s"]["edited_rows"]
+        if "changes_to_table_%s" % key in st.session_state:
+            changes = st.session_state["changes_to_table_%s" % key]["edited_rows"]
             for row in changes:
                 for col in changes[row]:
                     row_offset = row + ((page - 1) * page_size)

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -15,6 +15,7 @@ from sibylapp2.config import (
     get_color_scheme,
 )
 from sibylapp2.compute.api import modify_features, format_feature_df_for_modify
+from sibylapp2.compute import features
 
 NEUT_EM = "🟪"
 BLANK_EM = "⬜"
@@ -175,8 +176,12 @@ def show_table(df, key, style_function=None, enable_editing=True):
 
     def save_changes():
         st.session_state["original_table_%s" % key] = st.session_state["edited_table_%s" % key]
-        modify_features(format_feature_df_for_modify(st.session_state["edited_table_%s" % key]))
+        modify_features(
+            format_feature_df_for_modify(st.session_state["edited_table_%s" % key].copy())
+        )
         st.session_state["changes_made"] = False
+        del st.session_state["changes_to_table"]
+        features.get_features.clear()
 
     if enable_editing:
         if "changes_made" not in st.session_state:
@@ -184,7 +189,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
         reset_changes_container.button(
             "Reset changes", disabled=not st.session_state["changes_made"], on_click=reset_changes
         )
-        save_changes_container.button(
+        save = save_changes_container.button(
             "Save changes to database",
             disabled=not st.session_state["changes_made"],
             on_click=save_changes,

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -5,6 +5,8 @@ import math
 import pandas as pd
 import streamlit as st
 
+from sibylapp2.compute import features, importance
+from sibylapp2.compute.api import format_feature_df_for_modify, modify_features
 from sibylapp2.compute.context import get_term
 from sibylapp2.config import (
     NEGATIVE_TERM,
@@ -14,8 +16,6 @@ from sibylapp2.config import (
     get_bar_length,
     get_color_scheme,
 )
-from sibylapp2.compute.api import modify_features, format_feature_df_for_modify
-from sibylapp2.compute import features, importance
 
 NEUT_EM = "🟪"
 BLANK_EM = "⬜"

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -90,7 +90,44 @@ def get_pos_neg_names():
         return "purple", "yellow"
 
 
-def show_table(df, key=None, style_function=None):
+def show_table(df, key, style_function=None, enable_editing=True, column_config="default"):
+    """
+    Show a table with pagination and editing capabilities.
+
+    Args:
+        df (DataFrame): Dataframe to show
+        key (string): Key to use for the table
+        style_function (function): Function to apply to the dataframe before showing
+        enable_editing (bool): Whether to enable any editing of the table.
+                To selectively disable editing by column, use column_configs
+        column_config (dict): Dictionary of column names to column config.
+                If set to default, Feature and Category columns will be editable and
+                the category column will be a selectbox.
+
+    Returns:
+        None
+    """
+    st.session_state["original_table_%s" % key] = df.copy()
+    if ("edited_table_%s" % key) not in st.session_state:
+        st.session_state["edited_table_%s" % key] = df.copy()
+    df = st.session_state["edited_table_%s" % key]
+
+    if enable_editing and column_config is "default":
+        column_config = {}
+        for column in df:
+            if column == "Category":
+                column_config[column] = st.column_config.SelectboxColumn(
+                    options=df[column].unique(), disabled=False, label=get_term(column)
+                )
+            elif column == "Feature":
+                column_config[column] = st.column_config.TextColumn(
+                    disabled=False, label=get_term(column)
+                )
+            else:
+                column_config[column] = st.column_config.Column(
+                    disabled=True, label=get_term(column)
+                )
+
     table = st.container()
     _, col1, col2 = st.columns((4, 1, 1))
     with col2:
@@ -98,6 +135,7 @@ def show_table(df, key=None, style_function=None):
         if key is not None:
             page_size_key = "%s%s" % (key, "_per_page")
         page_size = st.selectbox("Rows per page", [10, 25, 50], key=page_size_key)
+        reset_changes_container = st.empty()
     with col1:
         page_key = "page_key"
         if key is not None:
@@ -110,22 +148,39 @@ def show_table(df, key=None, style_function=None):
             max_value=int(df.shape[0] / page_size) + 1,
             key=page_key,
         )
-    renames = {}
-    for column in df:
-        renames[column] = get_term(column)
-    df = df.rename(columns=renames)
+        save_changes_container = st.empty()
+
     df = df[(page - 1) * page_size : page * page_size]
 
     # pandas styler must be display in whole
     if style_function is not None:
         df = style_function(df)
+
+    def update_table_with_changes():
+        if "changes_to_table" in st.session_state:
+            changes = st.session_state["changes_to_table"]["edited_rows"]
+            for row in changes:
+                for col in changes[row]:
+                    st.session_state["edited_table_%s" % key].iloc[row][col] = changes[row][col]
+
     table.data_editor(
         df,
         hide_index=True,
         use_container_width=True,
         num_rows="fixed",
-        disabled=True,
+        column_config=column_config,
+        disabled=not enable_editing,
+        key="changes_to_table",
+        on_change=update_table_with_changes,
     )
+
+    """if enable_editing:
+        changes_made = len(st.session_state["changed_table"]["edited_rows"]) > 0
+        reset_changes_container.button("Reset changes", disabled=not changes_made)
+        save_changes_container.button(
+            "Save changes to database",
+            disabled=not changes_made,
+        )"""
 
 
 def generate_bars(values, neutral=False, show_number=False):

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -15,7 +15,7 @@ from sibylapp2.config import (
     get_color_scheme,
 )
 from sibylapp2.compute.api import modify_features, format_feature_df_for_modify
-from sibylapp2.compute import features
+from sibylapp2.compute import features, importance
 
 NEUT_EM = "🟪"
 BLANK_EM = "⬜"
@@ -115,7 +115,9 @@ def show_table(df, key, style_function=None, enable_editing=True):
     for column in df:
         if column == "Category":
             column_config[column] = st.column_config.SelectboxColumn(
-                options=df[column].unique(), disabled=not enable_editing, label=get_term(column)
+                options=features.get_categories(),
+                disabled=not enable_editing,
+                label=get_term(column),
             )
         elif column == "Feature":
             column_config[column] = st.column_config.TextColumn(
@@ -163,6 +165,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
                     ]
                     st.session_state["changes_made"] = True
 
+    st.write(column_config)
     table.data_editor(
         df,
         hide_index=True,
@@ -185,6 +188,7 @@ def show_table(df, key, style_function=None, enable_editing=True):
         st.session_state["changes_made"] = False
         del st.session_state["changes_to_table_%s" % key]
         features.get_features.clear()
+        importance.compute_importance.clear()  # Should refactor to avoid having to do this
 
     if enable_editing:
         if "changes_made" not in st.session_state:


### PR DESCRIPTION
### Closing issues

Closes #99 

### Description

Users can now change feature table descriptions and categories and then upload those changes to the database.
This version has a slight issue where after saving changes to the database on one page, the others have to be refreshed to reflect those changes. Will aim to fix this after refactor

