### PR TITLE
Adding "edit features" page and removing this functionality from other pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,13 +5,13 @@ from sibylapp2.config import get_pages_to_show
 from sibylapp2.pages import (
     Change_over_Time,
     Compare_Entities,
+    Edit_Features,
     Experiment_with_Changes,
     Explore_a_Prediction,
     Prediction_Summary,
     Settings,
     Similar_Entities,
     Understand_the_Model,
-    Edit_Features,
 )
 from sibylapp2.view.utils import setup
 

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from sibylapp2.pages import (
     Settings,
     Similar_Entities,
     Understand_the_Model,
+    Edit_Features,
 )
 from sibylapp2.view.utils import setup
 
@@ -24,6 +25,7 @@ ALL_PAGES = {
     "Experiment with Changes": Experiment_with_Changes,
     "Change over Time": Change_over_Time,
     "Understand the Model": Understand_the_Model,
+    "Edit Features": Edit_Features,
     "Settings": Settings,
 }
 

--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -23,6 +23,7 @@ PAGES_TO_SHOW: # Set to a list of pages or "all" to show all pages
 - Similar Entities
 - Experiment with Changes
 - Understand the Model
+- Edit Features
 - Settings
 ALLOW_PAGE_SELECTION:  # If true, allow user to select which pages to show (requires settings page)
 

--- a/sibylapp2/pages/Edit_Features.py
+++ b/sibylapp2/pages/Edit_Features.py
@@ -7,6 +7,13 @@ from sibylapp2.compute.api import format_feature_df_for_modify, modify_features
 from sibylapp2.view.utils import filtering
 
 
+def view_instructions():
+    with st.sidebar.expander("How to Use"):
+        st.write(
+            "On this page you can add and edit feature categories, and modify feature descriptions"
+        )
+
+
 def submit_new_category():
     if st.session_state["new_category"] in st.session_state["categories"]:
         st.toast("Category already exists", icon="⚠️")
@@ -29,6 +36,8 @@ def apply_changes():
 
 
 def main():
+    view_instructions()
+
     if "changes_made" not in st.session_state:
         st.session_state["changes_made"] = False
     filtering.view_filtering()

--- a/sibylapp2/pages/Edit_Features.py
+++ b/sibylapp2/pages/Edit_Features.py
@@ -1,8 +1,10 @@
+# pylint: disable=invalid-name
+
 import streamlit as st
-from sibylapp2.compute import features
-from sibylapp2.view.utils import filtering
+
+from sibylapp2.compute import context, features, importance
 from sibylapp2.compute.api import format_feature_df_for_modify, modify_features
-from sibylapp2.compute import importance, context
+from sibylapp2.view.utils import filtering
 
 
 def submit_new_category():

--- a/sibylapp2/pages/Edit_Features.py
+++ b/sibylapp2/pages/Edit_Features.py
@@ -1,0 +1,44 @@
+import streamlit as st
+from sibylapp2.compute import features
+from sibylapp2.view.utils import filtering
+
+
+def main():
+    filtering.view_filtering()
+    feature_table = features.get_features()
+
+    if "categories" not in st.session_state:
+        st.session_state["categories"] = list(feature_table["Category"].unique())
+
+    def submit_new_category():
+        if st.session_state["new_category"] in st.session_state["categories"]:
+            st.toast("Category already exists", icon="⚠️")
+            st.session_state["new_category"] = None
+            return
+        if not st.session_state["new_category"]:
+            return
+        st.session_state["categories"].append(st.session_state["new_category"])
+        st.session_state["new_category"] = None
+
+    st.text_input("Add a new category", key="new_category", on_change=submit_new_category)
+
+    column_config = {
+        "Category": st.column_config.SelectboxColumn(
+            options=st.session_state["categories"],
+            default=st.session_state["categories"][0],
+            required=True,
+        )
+    }
+    st.data_editor(
+        feature_table,
+        hide_index=True,
+        use_container_width=True,
+        key="feature_table",
+        column_config=column_config,
+    )
+    button_col1, button_col2, _ = st.columns((1, 1, 5))
+    button_col1.button("Reset changes", use_container_width=True)
+    button_col2.button(
+        "Save changes to database",
+        use_container_width=True,
+    )

--- a/sibylapp2/pages/Edit_Features.py
+++ b/sibylapp2/pages/Edit_Features.py
@@ -1,24 +1,41 @@
 import streamlit as st
 from sibylapp2.compute import features
 from sibylapp2.view.utils import filtering
+from sibylapp2.compute.api import format_feature_df_for_modify, modify_features
+from sibylapp2.compute import importance, context
+
+
+def submit_new_category():
+    if st.session_state["new_category"] in st.session_state["categories"]:
+        st.toast("Category already exists", icon="⚠️")
+        st.session_state["new_category"] = None
+        return
+    if not st.session_state["new_category"]:
+        return
+    st.session_state["categories"].append(st.session_state["new_category"])
+    st.session_state["new_category"] = None
+    st.toast("Added category successfully", icon="✅")
+
+
+def apply_changes():
+    if "feature_table_changes" in st.session_state:
+        changes = st.session_state["feature_table_changes"]["edited_rows"]
+        for row in changes:
+            for col in changes[row]:
+                st.session_state["edited_table"].iloc[row][col] = changes[row][col]
+                st.session_state["changes_made"] = True
 
 
 def main():
+    if "changes_made" not in st.session_state:
+        st.session_state["changes_made"] = False
     filtering.view_filtering()
     feature_table = features.get_features()
+    if "edited_table" not in st.session_state:
+        st.session_state["edited_table"] = feature_table.copy()
 
     if "categories" not in st.session_state:
         st.session_state["categories"] = list(feature_table["Category"].unique())
-
-    def submit_new_category():
-        if st.session_state["new_category"] in st.session_state["categories"]:
-            st.toast("Category already exists", icon="⚠️")
-            st.session_state["new_category"] = None
-            return
-        if not st.session_state["new_category"]:
-            return
-        st.session_state["categories"].append(st.session_state["new_category"])
-        st.session_state["new_category"] = None
 
     st.text_input("Add a new category", key="new_category", on_change=submit_new_category)
 
@@ -30,15 +47,36 @@ def main():
         )
     }
     st.data_editor(
-        feature_table,
+        filtering.process_options(st.session_state["edited_table"]),
         hide_index=True,
         use_container_width=True,
-        key="feature_table",
+        key="feature_table_changes",
         column_config=column_config,
+        on_change=apply_changes,
     )
+
+    def reset_changes():
+        st.session_state["edited_table"] = feature_table.copy()
+        st.session_state["changes_made"] = False
+
+    def save_changes():
+        modify_features(format_feature_df_for_modify(st.session_state["edited_table"].copy()))
+        features.get_features.clear()
+        importance.compute_importance.clear()
+        context.get_category_list.clear()
+        st.session_state["changes_made"] = False
+        del st.session_state["feature_table_changes"]
+
     button_col1, button_col2, _ = st.columns((1, 1, 5))
-    button_col1.button("Reset changes", use_container_width=True)
+    button_col1.button(
+        "Reset changes",
+        use_container_width=True,
+        disabled=not st.session_state["changes_made"],
+        on_click=reset_changes,
+    )
     button_col2.button(
         "Save changes to database",
         use_container_width=True,
+        disabled=not st.session_state["changes_made"],
+        on_click=save_changes,
     )

--- a/sibylapp2/pages/Prediction_Summary.py
+++ b/sibylapp2/pages/Prediction_Summary.py
@@ -13,7 +13,6 @@ from sibylapp2.view.utils.helpers import generate_bars, show_table
 
 
 def single_row_plot(predictions):
-    # predictions = dict(sorted(predictions.items(), key=lambda item: item[1]))
     fig = px.bar(
         x=list(predictions.values()),
         y=list(predictions.keys()),
@@ -74,7 +73,7 @@ def multi_row_plot(predictions, proba_predictions=None):
         )
         if proba_predictions:
             fig.update_layout(yaxis_range=[0, 1])
-        # st.plotly_chart(fig, use_container_width=True)
+
         selected = plotly_events(fig)
     with col2:
         if len(selected) > 0:
@@ -112,7 +111,7 @@ def prediction_table(
         button_size_mod = 2
     else:
         button_size_mod = 4
-    show_table(df, key="prediction_table", enable_editing=False, button_size_mod=button_size_mod)
+    show_table(df, key="prediction_table", button_size_mod=button_size_mod)
 
 
 def pred_prob_to_raw_prob(pred_prob, pred):

--- a/sibylapp2/pages/Settings.py
+++ b/sibylapp2/pages/Settings.py
@@ -121,6 +121,7 @@ def main():
                     "Experiment with Changes",
                     "Change over Time",
                     "Understand the Model",
+                    "Edit Features",
                     "Settings",
                 ]
                 show_pages_bools = []

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -5,8 +5,7 @@ import math
 import pandas as pd
 import streamlit as st
 
-from sibylapp2.compute import features, importance
-from sibylapp2.compute.api import format_feature_df_for_modify, modify_features
+from sibylapp2.compute import features
 from sibylapp2.compute.context import get_term
 from sibylapp2.config import (
     NEGATIVE_TERM,

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -96,7 +96,7 @@ def get_pos_neg_names():
         return "purple", "yellow"
 
 
-def show_table(df, key, style_function=None, enable_editing=False, button_size_mod=4):
+def show_table(df, key, style_function=None, button_size_mod=4):
     """
     Show a table with pagination and editing capabilities.
 
@@ -112,23 +112,17 @@ def show_table(df, key, style_function=None, enable_editing=False, button_size_m
     Returns:
         None
     """
-    if enable_editing:
-        st.session_state["original_table_%s" % key] = df.copy()
-        if ("edited_table_%s" % key) not in st.session_state:
-            st.session_state["edited_table_%s" % key] = df.copy()
-        df = st.session_state["edited_table_%s" % key]
-
     column_config = {}
     for column in df:
         if column == "Category":
             column_config[column] = st.column_config.SelectboxColumn(
                 options=features.get_categories(),
-                disabled=not enable_editing,
+                disabled=True,
                 label=get_term(column),
             )
         elif column == "Feature":
             column_config[column] = st.column_config.TextColumn(
-                disabled=not enable_editing, label=get_term(column)
+                disabled=True, label=get_term(column)
             )
         else:
             column_config[column] = st.column_config.Column(disabled=True, label=get_term(column))
@@ -140,7 +134,6 @@ def show_table(df, key, style_function=None, enable_editing=False, button_size_m
         if key is not None:
             page_size_key = "%s%s" % (key, "_per_page")
         page_size = st.selectbox("Rows per page", [10, 25, 50], key=page_size_key)
-        reset_changes_container = st.empty()
     with col1:
         page_key = "page_key"
         if key is not None:
@@ -153,24 +146,12 @@ def show_table(df, key, style_function=None, enable_editing=False, button_size_m
             max_value=int(df.shape[0] / page_size) + 1,
             key=page_key,
         )
-        save_changes_container = st.empty()
 
     df = df[(page - 1) * page_size : page * page_size]
 
     # pandas styler must be display in whole
     if style_function is not None:
         df = style_function(df)
-
-    def update_table_with_changes():
-        if "changes_to_table_%s" % key in st.session_state:
-            changes = st.session_state["changes_to_table_%s" % key]["edited_rows"]
-            for row in changes:
-                for col in changes[row]:
-                    row_offset = row + ((page - 1) * page_size)
-                    st.session_state["edited_table_%s" % key].iloc[row_offset][col] = changes[row][
-                        col
-                    ]
-                    st.session_state["changes_made"] = True
 
     table.data_editor(
         df,
@@ -179,34 +160,7 @@ def show_table(df, key, style_function=None, enable_editing=False, button_size_m
         num_rows="fixed",
         column_config=column_config,
         key="changes_to_table_%s" % key,
-        on_change=update_table_with_changes,
     )
-
-    def reset_changes():
-        st.session_state["edited_table_%s" % key] = st.session_state["original_table_%s" % key]
-        st.session_state["changes_made"] = False
-
-    def save_changes():
-        st.session_state["original_table_%s" % key] = st.session_state["edited_table_%s" % key]
-        modify_features(
-            format_feature_df_for_modify(st.session_state["edited_table_%s" % key].copy())
-        )
-        st.session_state["changes_made"] = False
-        del st.session_state["changes_to_table_%s" % key]
-        features.get_features.clear()
-        importance.compute_importance.clear()  # Should refactor to avoid having to do this
-
-    if enable_editing:
-        if "changes_made" not in st.session_state:
-            st.session_state["changes_made"] = False
-        reset_changes_container.button(
-            "Reset changes", disabled=not st.session_state["changes_made"], on_click=reset_changes
-        )
-        save_changes_container.button(
-            "Save changes to database",
-            disabled=not st.session_state["changes_made"],
-            on_click=save_changes,
-        )
 
 
 def generate_bars(values, neutral=False, show_number=False):


### PR DESCRIPTION
### Closing issues

Closes #125 

### Description

Allowing users to edit feature names on all tables has caused several bugs and greatly complicated code, and may be confusing. Instead, I'm moving all this functionality to a new page that can be enabled when database changes are desired. All other tables are no longer editable.
