### PR TITLE
Contribution table to feature view

### DIFF
--- a/sibylapp2/compute/features.py
+++ b/sibylapp2/compute/features.py
@@ -18,6 +18,12 @@ def get_features(include_type=False, include_values=False) -> pd.DataFrame:
 
 
 @st.cache_data(show_spinner="Fetching data...")
+def get_feature_description(feature: str) -> str:
+    feature_description = get_features().loc[feature, "Feature"]
+    return feature_description
+
+
+@st.cache_data(show_spinner="Fetching data...")
 def get_entity(eid: str, row_id: str | None = None) -> pd.Series:
     feature_values = api.fetch_entity(eid, row_id)
     return feature_values

--- a/sibylapp2/pages/Explore_a_Prediction.py
+++ b/sibylapp2/pages/Explore_a_Prediction.py
@@ -10,6 +10,16 @@ from sibylapp2.view.utils import display, filtering
 import pandas as pd
 
 
+def get_selected_features(feature_names):
+    features = []
+    if "changes_to_table_feature_contributions" in st.session_state:
+        changes = st.session_state["changes_to_table_feature_contributions"]["edited_rows"]
+        for row in changes:
+            if "Show feature plot?" in changes[row] and changes[row]["Show feature plot?"]:
+                features.append(feature_names.iloc[row])
+    return features
+
+
 def main():
     # Sidebar ------------------------------------
     display.show_probability_select_box()
@@ -17,12 +27,30 @@ def main():
     filtering.view_selection()
     feature_contribution.view_instructions()
 
-    # Global options ------------------------------
-    filtering.view_filtering()
-
-    feature_contribution.view(
-        st.session_state["eid"],
-        st.session_state["model_id"],
-        key="feature_contributions",
-        row_id=st.session_state["row_id"],
+    tab = stx.tab_bar(
+        data=[
+            stx.TabBarItemData(
+                id=1, title=get_term(f"{get_term('Feature')} Contributions"), description=""
+            ),
+            stx.TabBarItemData(
+                id=2,
+                title="Explore Selected %s" % get_term("Feature", plural=True),
+                description="",
+            ),
+        ],
+        default=1,
     )
+
+    # Global options ------------------------------
+    if tab == "1":
+        filtering.view_filtering()
+
+        selected_features = feature_contribution.view(
+            st.session_state["eid"],
+            st.session_state["model_id"],
+            key="feature_contributions",
+            row_id=st.session_state["row_id"],
+        )
+        st.write(selected_features)
+    if tab == "2":
+        st.write(st.session_state["changes_to_table_feature_contributions"])

--- a/sibylapp2/pages/Explore_a_Prediction.py
+++ b/sibylapp2/pages/Explore_a_Prediction.py
@@ -7,6 +7,8 @@ from sibylapp2.compute.context import get_term
 from sibylapp2.view import feature_contribution
 from sibylapp2.view.utils import display, filtering
 
+import pandas as pd
+
 
 def main():
     # Sidebar ------------------------------------
@@ -18,17 +20,9 @@ def main():
     # Global options ------------------------------
     filtering.view_filtering()
 
-    tab = stx.tab_bar(
-        data=[
-            stx.TabBarItemData(id=1, title=get_term("Feature Contributions"), description=""),
-        ],
-        default=1,
+    feature_contribution.view(
+        st.session_state["eid"],
+        st.session_state["model_id"],
+        key="feature_contributions",
+        row_id=st.session_state["row_id"],
     )
-
-    if tab == "1":
-        feature_contribution.view(
-            st.session_state["eid"],
-            st.session_state["model_id"],
-            key="feature_contributions",
-            row_id=st.session_state["row_id"],
-        )

--- a/sibylapp2/pages/Explore_a_Prediction.py
+++ b/sibylapp2/pages/Explore_a_Prediction.py
@@ -7,6 +7,12 @@ from sibylapp2.compute.context import get_term
 from sibylapp2.view import feature_contribution
 from sibylapp2.view.utils import display, filtering
 
+from sibylapp2.view import explore_feature
+from sibylapp2.compute import entities, model
+from sibylapp2.compute.features import get_feature_description
+
+from sibylapp2.config import get_dataset_size
+
 import pandas as pd
 
 
@@ -51,6 +57,18 @@ def main():
             key="feature_contributions",
             row_id=st.session_state["row_id"],
         )
-        st.write(selected_features)
-    if tab == "2":
-        st.write(st.session_state["changes_to_table_feature_contributions"])
+        if selected_features:
+            if "dataset_eids" not in st.session_state:
+                st.session_state["dataset_eids"] = entities.get_eids(
+                    max_entities=get_dataset_size()
+                )
+            predictions = model.get_dataset_predictions(st.session_state["model_id"])
+            for selected_feature in selected_features:
+                st.subheader(get_feature_description(selected_feature))
+                explore_feature.view(
+                    st.session_state["dataset_eids"],
+                    predictions,
+                    selected_feature,
+                    st.session_state["model_id"],
+                    one_line=True,
+                )

--- a/sibylapp2/pages/Explore_a_Prediction.py
+++ b/sibylapp2/pages/Explore_a_Prediction.py
@@ -34,6 +34,7 @@ def main():
         st.session_state["model_id"],
         key="feature_contributions",
         row_id=st.session_state["row_id"],
+        include_feature_plot=True,
     )
     if selected_features:
         if "dataset_eids" not in st.session_state:

--- a/sibylapp2/pages/Understand_the_Model.py
+++ b/sibylapp2/pages/Understand_the_Model.py
@@ -74,6 +74,10 @@ def main():
                 global_contributions.view(eids, st.session_state["model_id"])
 
     if tab == "4":
+
+        def feature_name_to_description(name):
+            return features_values.loc[name, "Feature"]
+
         with placeholder:
             if len(eids) == 0:
                 st.warning("Select predictions above to see explanation!")
@@ -81,6 +85,7 @@ def main():
                 feature = st.selectbox(
                     "Select a %s" % get_term("feature"),
                     filtering.process_search_on_features(features_values),
+                    format_func=feature_name_to_description,
                 )
                 explore_feature.view(
                     eids, predictions, feature, st.session_state["model_id"], discrete

--- a/sibylapp2/view/explore_feature.py
+++ b/sibylapp2/view/explore_feature.py
@@ -77,22 +77,27 @@ def generate_feature_plot(eids, predictions, feature, model_id, discrete=False):
     return fig
 
 
-def view(eids, predictions, feature, model_id, discrete=False):
+def view(eids, predictions, feature, model_id, discrete=False, one_line=False):
     col1, col2 = st.columns(2)
     with col1:
         fig1 = generate_feature_plot(eids, predictions, feature, model_id, discrete)
         selected_index = plotly_events(fig1)
-        fig2 = generate_feature_distribution_plot(eids, feature, model_id=model_id)
-        st.plotly_chart(fig2)
+        if not one_line:
+            fig2 = generate_feature_distribution_plot(eids, feature, model_id=model_id)
+            st.plotly_chart(fig2)
     with col2:
-        if len(selected_index) > 0:
-            eid = eids[selected_index[0]["pointIndex"]]
-            st.subheader(
-                "Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid)
-            )
-            feature_contribution.view(eid, model_id, save_space=True, key="explore_feature")
+        if one_line:
+            fig2 = generate_feature_distribution_plot(eids, feature, model_id=model_id)
+            st.plotly_chart(fig2)
         else:
-            st.warning("Select a point in the plot to see all contributions!")
+            if len(selected_index) > 0:
+                eid = eids[selected_index[0]["pointIndex"]]
+                st.subheader(
+                    "Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid)
+                )
+                feature_contribution.view(eid, model_id, save_space=True, key="explore_feature")
+            else:
+                st.warning("Select a point in the plot to see all contributions!")
 
 
 def view_instructions():

--- a/sibylapp2/view/explore_feature.py
+++ b/sibylapp2/view/explore_feature.py
@@ -18,7 +18,6 @@ def generate_feature_distribution_plot(eids, feature, model_id):
     if pd.api.types.is_numeric_dtype(pd.to_numeric(data, errors="ignore")):
         trace1 = go.Box(x=data, boxpoints="all", name="", marker_color="rgb(84, 31, 63)")
         fig = go.Figure(data=[trace1])
-        fig.update_layout(title="Distributions for '%s'" % feature)
         return fig
     else:
         fig = px.pie(

--- a/sibylapp2/view/explore_feature.py
+++ b/sibylapp2/view/explore_feature.py
@@ -73,14 +73,29 @@ def generate_feature_plot(eids, predictions, feature, model_id, discrete=False):
         hover_data=hover_data,
     )
     fig.update_traces(opacity=0.7, marker=dict(size=10, line=dict(width=0.5, color="black")))
-    return fig
+    fig.update_layout(hovermode="closest")
+    if not discrete:
+        return fig, df["ID"]
+    else:
+        return fig, [df[df["Prediction"] == pred]["ID"] for pred in sorted(set(df["Prediction"]))]
 
 
 def view(eids, predictions, feature, model_id, discrete=False, one_line=False):
+    if feature is None:
+        st.warning("Please select a feature to explore!")
+        return
     col1, col2 = st.columns(2)
     with col1:
-        fig1 = generate_feature_plot(eids, predictions, feature, model_id, discrete)
+        fig1, ids = generate_feature_plot(eids, predictions, feature, model_id, discrete)
         selected_index = plotly_events(fig1)
+        if not discrete:
+            selected_id = ids[selected_index[0]["pointIndex"]] if len(selected_index) > 0 else None
+        else:
+            selected_id = (
+                ids[selected_index[0]["curveNumber"]][selected_index[0]["pointIndex"]]
+                if len(selected_index) > 0
+                else None
+            )
         if not one_line:
             fig2 = generate_feature_distribution_plot(eids, feature, model_id=model_id)
             st.plotly_chart(fig2)
@@ -89,20 +104,21 @@ def view(eids, predictions, feature, model_id, discrete=False, one_line=False):
             fig2 = generate_feature_distribution_plot(eids, feature, model_id=model_id)
             st.plotly_chart(fig2)
         else:
-            if len(selected_index) > 0:
-                eid = eids[selected_index[0]["pointIndex"]]
+            if selected_id:
                 st.subheader(
-                    "Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid)
+                    "Contributions for {entity} {eid}".format(
+                        entity=get_term("Entity"), eid=selected_id
+                    )
                 )
                 feature_contribution.view(
-                    eid,
+                    selected_id,
                     model_id,
                     save_space=True,
                     key="explore_feature",
                     include_feature_plot=False,
                 )
             else:
-                st.warning("Select a point in the plot to see all contributions!")
+                st.info("Select a point in the plot to see all contributions!")
 
 
 def view_instructions():

--- a/sibylapp2/view/explore_feature.py
+++ b/sibylapp2/view/explore_feature.py
@@ -94,7 +94,13 @@ def view(eids, predictions, feature, model_id, discrete=False, one_line=False):
                 st.subheader(
                     "Contributions for {entity} {eid}".format(entity=get_term("Entity"), eid=eid)
                 )
-                feature_contribution.view(eid, model_id, save_space=True, key="explore_feature")
+                feature_contribution.view(
+                    eid,
+                    model_id,
+                    save_space=True,
+                    key="explore_feature",
+                    include_feature_plot=False,
+                )
             else:
                 st.warning("Select a point in the plot to see all contributions!")
 

--- a/sibylapp2/view/feature_contribution.py
+++ b/sibylapp2/view/feature_contribution.py
@@ -8,6 +8,7 @@ from sibylapp2.view.utils.helpers import show_legend
 
 def show_sorted_contributions(to_show, sort_by, key):
     show_legend()
+    selected_features = []
 
     if sort_by == "Side-by-side":
         col1, col2 = st.columns(2)
@@ -17,18 +18,20 @@ def show_sorted_contributions(to_show, sort_by, key):
                 by="Contribution", axis="index", ascending=False
             )
             to_show_neg = filtering.process_options(to_show_neg)
-            helpers.show_table(
+            edited_table = helpers.show_table(
                 to_show_neg.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_neg")
             )
+            selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
         with col2:
             st.subheader(get_term("Positive"))
             to_show_pos = to_show[to_show["Contribution Value"] >= 0].sort_values(
                 by="Contribution", axis="index", ascending=False
             )
             to_show_pos = filtering.process_options(to_show_pos)
-            helpers.show_table(
+            edited_table = helpers.show_table(
                 to_show_pos.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_pos")
             )
+            selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
     else:
         if sort_by == "Absolute":
             to_show = to_show.reindex(
@@ -41,7 +44,11 @@ def show_sorted_contributions(to_show, sort_by, key):
             to_show = to_show.sort_values(by="Contribution Value", axis="index")
             to_show = to_show[to_show["Contribution Value"] < 0]
         to_show = filtering.process_options(to_show)
-        helpers.show_table(to_show.drop("Contribution Value", axis="columns"), key=key)
+        edited_table = helpers.show_table(
+            to_show.drop("Contribution Value", axis="columns"), key=key
+        )
+        selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
+    return selected_features
 
 
 def format_contributions_to_view(eid, model_id, row_id=None, show_number=False):
@@ -89,7 +96,7 @@ def view(eid, model_id, key, row_id=None, save_space=False):
     to_show = format_contributions_to_view(eid, model_id, row_id=row_id, show_number=show_number)
     to_show["Show feature plot?"] = False
 
-    show_sorted_contributions(to_show, sort_by, key=key)
+    return show_sorted_contributions(to_show, sort_by, key=key)
 
 
 def view_instructions():

--- a/sibylapp2/view/feature_contribution.py
+++ b/sibylapp2/view/feature_contribution.py
@@ -87,6 +87,7 @@ def view(eid, model_id, key, row_id=None, save_space=False):
         )
 
     to_show = format_contributions_to_view(eid, model_id, row_id=row_id, show_number=show_number)
+    to_show["Show feature plot?"] = False
 
     show_sorted_contributions(to_show, sort_by, key=key)
 

--- a/sibylapp2/view/feature_contribution.py
+++ b/sibylapp2/view/feature_contribution.py
@@ -21,7 +21,8 @@ def show_sorted_contributions(to_show, sort_by, key):
             edited_table = helpers.show_table(
                 to_show_neg.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_neg")
             )
-            selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
+            if "Show feature plot?" in edited_table.columns:
+                selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
         with col2:
             st.subheader(get_term("Positive"))
             to_show_pos = to_show[to_show["Contribution Value"] >= 0].sort_values(
@@ -31,7 +32,8 @@ def show_sorted_contributions(to_show, sort_by, key):
             edited_table = helpers.show_table(
                 to_show_pos.drop("Contribution Value", axis="columns"), key="%s%s" % (key, "_pos")
             )
-            selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
+            if "Show feature plot?" in edited_table.columns:
+                selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
     else:
         if sort_by == "Absolute":
             to_show = to_show.reindex(
@@ -47,7 +49,8 @@ def show_sorted_contributions(to_show, sort_by, key):
         edited_table = helpers.show_table(
             to_show.drop("Contribution Value", axis="columns"), key=key
         )
-        selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
+        if "Show feature plot?" in edited_table.columns:
+            selected_features.extend(edited_table[edited_table["Show feature plot?"]].index)
     return selected_features
 
 
@@ -71,7 +74,7 @@ def format_contributions_to_view(eid, model_id, row_id=None, show_number=False):
     return full_df
 
 
-def view(eid, model_id, key, row_id=None, save_space=False):
+def view(eid, model_id, key, row_id=None, save_space=False, include_feature_plot=False):
     """
     `eid_for_rows` is only used when `use_row_id` == True.
     `eid` are used as row_id when `use_row_id` == True
@@ -94,7 +97,8 @@ def view(eid, model_id, key, row_id=None, save_space=False):
         )
 
     to_show = format_contributions_to_view(eid, model_id, row_id=row_id, show_number=show_number)
-    to_show["Show feature plot?"] = False
+    if include_feature_plot:
+        to_show["Show feature plot?"] = False
 
     return show_sorted_contributions(to_show, sort_by, key=key)
 

--- a/sibylapp2/view/utils/filtering.py
+++ b/sibylapp2/view/utils/filtering.py
@@ -198,10 +198,12 @@ def process_search(to_show):
 
 def process_search_on_features(features):
     if st.session_state["search_term"] is not None:
-        features = features.index[
-            features.index.str.contains(st.session_state["search_term"], case=False, na=False)
+        features = features[
+            features["Feature"].str.contains(st.session_state["search_term"], case=False, na=False)
         ]
-    return features
+    if len(st.session_state["filters"]) > 0:
+        features = features[features["Category"].isin(st.session_state["filters"])]
+    return features.index
 
 
 def process_filter(to_show):

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -123,6 +123,8 @@ def show_table(df, key, style_function=None, button_size_mod=4):
             column_config[column] = st.column_config.TextColumn(
                 disabled=True, label=get_term(column)
             )
+        elif column == "Show feature plot?":
+            column_config[column] = st.column_config.CheckboxColumn(disabled=False)
         else:
             column_config[column] = st.column_config.Column(disabled=True, label=get_term(column))
 

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -154,7 +154,7 @@ def show_table(df, key, style_function=None, button_size_mod=4):
     if style_function is not None:
         df = style_function(df)
 
-    table.data_editor(
+    return table.data_editor(
         df,
         hide_index=True,
         use_container_width=True,


### PR DESCRIPTION
### Closing issues

Closes #25 

### Description

The explore-a-feature page now includes a method for getting the feature explorations on the same dashboard for each feature.
While I'm in the code, I'm also fixing several bugs with the explore-a-feature interface:
- The correct point is now selected for multi-class cases
- Feature descriptions are now shown instead of names
- Search/filter both now work on the feature selection
- Filtering out all features will no longer cause an error

