### PR TITLE
Removing typing for 3.9 support

### DIFF
--- a/sibylapp2/compute/api.py
+++ b/sibylapp2/compute/api.py
@@ -115,9 +115,7 @@ def fetch_modified_prediction(
     return prediction
 
 
-def fetch_predictions(
-    eids, row_ids=None, model_id=fetch_model_id(), return_proba=False
-) -> dict[str, list[int | float]]:
+def fetch_predictions(eids, row_ids=None, model_id=fetch_model_id(), return_proba=False):
     json = {
         "eids": eids,
         "model_id": model_id,
@@ -181,7 +179,7 @@ def modify_features(new_features):
     api_put("features/", json={"features": new_features})
 
 
-def fetch_entity(eid, row_id=None) -> pd.Series:
+def fetch_entity(eid, row_id=None):
     url = f"entities/{eid}"
     if row_id is not None:
         url += f"/?row_id={row_id}"

--- a/sibylapp2/compute/features.py
+++ b/sibylapp2/compute/features.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pandas as pd
 import streamlit as st
 
 from sibylapp2.compute import api

--- a/sibylapp2/compute/features.py
+++ b/sibylapp2/compute/features.py
@@ -7,7 +7,7 @@ from sibylapp2.compute import api
 
 
 @st.cache_data(show_spinner="Fetching data...")
-def get_features(include_type=False, include_values=False) -> pd.DataFrame:
+def get_features(include_type=False, include_values=False):
     columns = ["Category", "Feature"]
     if include_type:
         columns.append("Type")
@@ -18,13 +18,13 @@ def get_features(include_type=False, include_values=False) -> pd.DataFrame:
 
 
 @st.cache_data(show_spinner="Fetching data...")
-def get_feature_description(feature: str) -> str:
+def get_feature_description(feature: str):
     feature_description = get_features().loc[feature, "Feature"]
     return feature_description
 
 
 @st.cache_data(show_spinner="Fetching data...")
-def get_entity(eid: str, row_id: str | None = None) -> pd.Series:
+def get_entity(eid: str, row_id: str | None = None):
     feature_values = api.fetch_entity(eid, row_id)
     return feature_values
 

--- a/sibylapp2/compute/model.py
+++ b/sibylapp2/compute/model.py
@@ -10,17 +10,13 @@ def get_models():
 
 
 @st.cache_data(show_spinner="Getting model predictions...")
-def get_predictions(
-    eids, model_id=api.fetch_model_id(), return_proba=False
-) -> dict[str, list[int | float]]:
+def get_predictions(eids, model_id=api.fetch_model_id(), return_proba=False):
     predictions = api.fetch_predictions(eids, model_id=model_id, return_proba=return_proba)
     return predictions
 
 
 @st.cache_data(show_spinner="Getting model predictions...")
-def get_predictions_for_rows(
-    eid, row_ids, model_id=api.fetch_model_id(), return_proba=False
-) -> dict[str, list[int | float]]:
+def get_predictions_for_rows(eid, row_ids, model_id=api.fetch_model_id(), return_proba=False):
     predictions = api.fetch_predictions(
         [eid], row_ids, model_id=model_id, return_proba=return_proba
     )
@@ -28,9 +24,7 @@ def get_predictions_for_rows(
 
 
 @st.cache_data(show_spinner="Getting model predictions...")
-def get_dataset_predictions(
-    model_id=api.fetch_model_id(), return_proba=False
-) -> dict[str, list[int | float]]:
+def get_dataset_predictions(model_id=api.fetch_model_id(), return_proba=False):
     if "dataset_eids" not in st.session_state:
         st.session_state["dataset_eids"] = entities.get_eids(get_dataset_size())
     return get_predictions(

--- a/sibylapp2/view/utils/helpers.py
+++ b/sibylapp2/view/utils/helpers.py
@@ -57,7 +57,7 @@ def show_text_input_side_by_side(
     default_input: str | None = None,
     numeric: bool = False,
     **input_params,
-) -> int | float | str:
+):
     col1, col2 = st.columns([2, 2])
     col1.markdown(label)
 


### PR DESCRIPTION
We need to run sibylapp2 on machines with python 3.9, so I am removing type hints with | for now