### PR TITLE
Updating change over time plot

### DIFF
--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -10,7 +10,7 @@ LOAD_UPFRONT: true # If true, run heavy computations on initial load, else greed
 
 # APPLICATION-SPECIFIC CONFIGURATIONS (overrides API context) =====================================
 FLIP_COLORS: false # deprecated (use COLOR_SCHEME) keeping for api support
-COLOR_SCHEME: Reversed # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
+COLOR_SCHEME: Standard # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
 PREDICTION_TYPE: # One of "numeric", "boolean", "categorical"
 POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models

--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -10,7 +10,7 @@ LOAD_UPFRONT: true # If true, run heavy computations on initial load, else greed
 
 # APPLICATION-SPECIFIC CONFIGURATIONS (overrides API context) =====================================
 FLIP_COLORS: false # deprecated (use COLOR_SCHEME) keeping for api support
-COLOR_SCHEME: Standard # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
+COLOR_SCHEME: Reversed # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
 PREDICTION_TYPE: # One of "numeric", "boolean", "categorical"
 POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models
@@ -22,6 +22,7 @@ PAGES_TO_SHOW: # Set to a list of pages or "all" to show all pages
 - Explore a Prediction
 - Similar Entities
 - Experiment with Changes
+- Change over Time
 - Understand the Model
 - Edit Features
 - Settings

--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -18,14 +18,6 @@ PRED_FORMAT_STRING: # fstring for formatting numeric model outputs
 OVERRIDE_PRED_FORMAT: # If True, use "config.manual_pred_format_func" to format preds, ignoring previous 3 configs
 SUPPORT_PROBABILITY: # Only set this to True when model supports `predict_proba`
 PAGES_TO_SHOW: # Set to a list of pages or "all" to show all pages
-- Prediction Summary
-- Explore a Prediction
-- Similar Entities
-- Experiment with Changes
-- Change over Time
-- Understand the Model
-- Edit Features
-- Settings
 ALLOW_PAGE_SELECTION:  # If true, allow user to select which pages to show (requires settings page)
 
 # TIME-SERIES-SPECIFIC CONFIGUREATIONS ============================================================

--- a/sibylapp2/pages/Change_over_Time.py
+++ b/sibylapp2/pages/Change_over_Time.py
@@ -8,6 +8,7 @@ from sibylapp2.view.utils import display, filtering
 
 def main():
     # Sidebar ------------------------------------
+    st.session_state["display_proba"] = True
     display.show_probability_select_box()
     filtering.view_selection()
     temporal_change.view_instructions()

--- a/sibylapp2/view/plots/charts.py
+++ b/sibylapp2/view/plots/charts.py
@@ -28,20 +28,17 @@ def plot_temporal_line_charts(
     )
     if fig is None:
         fig = go.Figure()
-
-    fig.add_traces(
-        list(
-            px.line(
-                df,
-                x="time",
-                y="contribution",
-                color="feature",
-                markers=True,
-                color_discrete_sequence=px.colors.sequential.gray,
-            ).data
-        )
-    )
-
+    traces = px.line(
+        df,
+        x="time",
+        y="contribution",
+        color="feature",
+        markers=True,
+        color_discrete_sequence=px.colors.sequential.gray,
+    ).data
+    for trace in traces:
+        fig.add_trace(trace, secondary_y=secondary_y)
+    fig.add_hline(y=0, secondary_y=secondary_y, line_color="purple", line_dash="dash")
     fig.update_layout(
         xaxis=dict(
             tickmode="array",
@@ -157,9 +154,9 @@ def update_figure(
             title=yaxis2_label,
             tickfont=dict(size=20),
             titlefont=dict(size=20),
-            # overlaying="y",
-            # side="right",
-            # anchor="x",
+            overlaying="y",
+            side="right",
+            anchor="x",
             # range=[y_min - y_margin, y_max + y_margin],
         ),
         legend=dict(x=0, y=-0.2, traceorder="normal", orientation="h"),

--- a/sibylapp2/view/plots/charts.py
+++ b/sibylapp2/view/plots/charts.py
@@ -37,6 +37,7 @@ def plot_temporal_line_charts(
         color_discrete_sequence=px.colors.sequential.gray,
     ).data
     for trace in traces:
+        trace.legend = "legend2"
         fig.add_trace(trace, secondary_y=secondary_y)
     fig.add_hline(y=0, secondary_y=secondary_y, line_color="purple", line_dash="dash")
     fig.update_layout(
@@ -50,7 +51,7 @@ def plot_temporal_line_charts(
     return fig
 
 
-def plot_scatter_chart(df, fig=None):
+def plot_scatter_chart(df, fig=None, yaxis_range=None):
     """
     Plot scatter plot for the given dataframe. The dataframe must have the following columns:
         - time
@@ -92,7 +93,7 @@ def plot_scatter_chart(df, fig=None):
                 color = pos_color
             else:
                 color = neg_color
-            name = f"{get_term('Prediction')}: {pred_format_func(label)}"
+            name = f"{pred_format_func(label)}"
             if label in shown_legends:
                 showlegend = False
             else:
@@ -109,6 +110,7 @@ def plot_scatter_chart(df, fig=None):
                 fillcolor=color,
                 mode="none",
                 showlegend=showlegend,
+                legend="legend1",
             ),
         )
 
@@ -119,6 +121,8 @@ def plot_scatter_chart(df, fig=None):
             dtick=1,
         ),
     )
+    if yaxis_range is not None:
+        fig.update_yaxes(range=yaxis_range, secondary_y=False)
 
     return fig
 
@@ -159,6 +163,15 @@ def update_figure(
             anchor="x",
             # range=[y_min - y_margin, y_max + y_margin],
         ),
-        legend=dict(x=0, y=-0.2, traceorder="normal", orientation="h"),
+        legend1=dict(
+            x=0, y=-0.2, traceorder="normal", orientation="h", title=get_term("Prediction")
+        ),
+        legend2=dict(
+            x=0,
+            y=-0.3,
+            traceorder="normal",
+            orientation="h",
+            title=get_term("Feature", plural=True),
+        ),
     )
     return fig

--- a/sibylapp2/view/plots/charts.py
+++ b/sibylapp2/view/plots/charts.py
@@ -46,7 +46,7 @@ def plot_temporal_line_charts(
             tickvals=df["time"],
             dtick=1,
         ),
-        hoverdistance=20,
+        hoverdistance=50,
     )
     return fig
 

--- a/sibylapp2/view/plots/charts.py
+++ b/sibylapp2/view/plots/charts.py
@@ -1,11 +1,10 @@
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-
-from sibylapp2.config import pred_format_func, PREDICTION_TYPE, get_color_scheme, PredType
-from sibylapp2.compute.context import get_term
-import numpy as np
-
 import streamlit as st
+
+from sibylapp2.compute.context import get_term
+from sibylapp2.config import PREDICTION_TYPE, PredType, get_color_scheme, pred_format_func
 
 
 def plot_temporal_line_charts(
@@ -60,6 +59,7 @@ def plot_temporal_line_charts(
                     "<b>%{customdata[0]}</b><br>Lead time: %{x}<br>Contribution:"
                     " %{y}<br>Value:%{customdata[1]}<extra></extra>"
                 ),
+                legend="legend2",
             ),
             secondary_y=secondary_y,
         )

--- a/sibylapp2/view/plots/charts.py
+++ b/sibylapp2/view/plots/charts.py
@@ -63,18 +63,6 @@ def plot_temporal_line_charts(
             ),
             secondary_y=secondary_y,
         )
-
-    # traces = px.line(
-    #     df,
-    #     x="time",
-    #     y="contribution",
-    #     color="feature",
-    #     markers=True,
-    #     color_discrete_sequence=px.colors.sequential.gray,
-    # ).data
-    # for trace in traces:
-    #     trace.legend = "legend2"
-    #     fig.add_trace(trace, secondary_y=secondary_y)
     fig.add_hline(y=0, secondary_y=secondary_y, line_color="purple", line_dash="dash")
     fig.update_layout(
         xaxis=dict(
@@ -87,9 +75,9 @@ def plot_temporal_line_charts(
     return fig
 
 
-def plot_scatter_chart(df, fig=None, yaxis_range=None):
+def plot_prediction_regions(df, fig=None, yaxis_range=None):
     """
-    Plot scatter plot for the given dataframe. The dataframe must have the following columns:
+    Plot predictions regions for the given dataframe. The dataframe must have these columns:
         - time
         - value
         - labels
@@ -107,47 +95,28 @@ def plot_scatter_chart(df, fig=None, yaxis_range=None):
     if fig is None:
         fig = go.Figure()
 
-    change_indices = df[df["label"] != df["label"].shift(1)].index.tolist()
-    change_indices.append(len(df))
-    shown_legends = []
-    for i in range(len(change_indices) - 1):
-        start_idx = change_indices[i]
-        end_idx = change_indices[i + 1]
-        section_df = df[start_idx:end_idx]
-        if i < len(change_indices) - 2:
-            next_section_start = df.iloc[[end_idx]]
-            section_df = pd.concat([section_df, next_section_start])
-
-        label = section_df["label"].iloc[0]
+    for label in df["label"].unique():
+        section_df = df[df["label"] == label]
 
         if PREDICTION_TYPE != PredType.BOOLEAN:
             color = "rgba(183, 149, 230, .5)"
             name = get_term("Prediction")
-            showlegend = i == 0
         else:
             if label > 0.5:
                 color = pos_color
             else:
                 color = neg_color
             name = f"{pred_format_func(label)}"
-            if label in shown_legends:
-                showlegend = False
-            else:
-                showlegend = True
-                shown_legends.append(label)
-        # color = "blue" if label == "normal" else "red"
 
         fig.add_trace(
-            go.Scatter(
+            go.Bar(
                 x=section_df["time"],
                 y=section_df["value"],
                 name=name,
-                fill="tozeroy",
-                fillcolor=color,
-                mode="none",
-                showlegend=showlegend,
+                showlegend=True,
                 legend="legend1",
-            ),
+                marker_color=color,
+            )
         )
 
     fig.update_layout(
@@ -156,6 +125,7 @@ def plot_scatter_chart(df, fig=None, yaxis_range=None):
             tickvals=df["time"],
             dtick=1,
         ),
+        bargap=0.03,
     )
     if yaxis_range is not None:
         fig.update_yaxes(range=yaxis_range, secondary_y=False)

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -96,10 +96,11 @@ def plot_prediction_variation(
         probs.append(prediction_value)
 
     df = pd.DataFrame({"time": timeindex, "value": probs, "label": predictions})
-    # output_label = get_term("Prediction")
-    # if st.session_state["display_proba"]:
-    #     output_label = f"{POSITIVE_TERM} probability"
-    fig = charts.plot_scatter_chart(df, fig)
+
+    if st.session_state["display_proba"]:
+        fig = charts.plot_scatter_chart(df, fig, yaxis_range=[0, 1])
+    else:
+        fig = charts.plot_scatter_chart(df, fig)
     return fig
 
 

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -1,12 +1,12 @@
 import pandas as pd
 import streamlit as st
+from plotly.subplots import make_subplots
 
-from sibylapp2.compute import contributions, model, features
+from sibylapp2.compute import contributions, features, model
 from sibylapp2.compute.context import get_term
-from sibylapp2.config import TIME_UNIT, pred_format_func
+from sibylapp2.config import TIME_UNIT
 from sibylapp2.view.plots import charts
 from sibylapp2.view.utils import filtering, helpers
-from plotly.subplots import make_subplots
 
 
 def filter_contributions(to_show, sort_by, num_features=8):

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import streamlit as st
 
-from sibylapp2.compute import contributions, model
+from sibylapp2.compute import contributions, model, features
 from sibylapp2.compute.context import get_term
 from sibylapp2.config import TIME_UNIT, pred_format_func
 from sibylapp2.view.plots import charts
@@ -10,7 +10,7 @@ from plotly.subplots import make_subplots
 
 
 def filter_contributions(to_show, sort_by, num_features=8):
-    sort_columns = to_show.drop(columns="Feature").columns
+    sort_columns = to_show.drop(columns=["Feature", "Category"]).columns
     # filter by the contribution values at 0 lead
     if sort_by == "Absolute":
         to_show["Average_Abs"] = to_show[sort_columns].abs().mean(axis=1)
@@ -55,7 +55,8 @@ def get_contributions_variation(
 
         contributions_list.append(contribution_df.iloc[0].rename(int(model_id[:-1])))
     contributions_table = pd.concat(contributions_list, axis=1)
-    contributions_table["Feature"] = feature_name
+    feature_table = features.get_features()
+    contributions_table = pd.concat([feature_table, contributions_table], axis=1)
 
     return contributions_table
 

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -3,13 +3,13 @@ import streamlit as st
 
 from sibylapp2.compute import contributions, model
 from sibylapp2.compute.context import get_term
-from sibylapp2.config import MAX_FEATURES, TIME_UNIT, pred_format_func
+from sibylapp2.config import TIME_UNIT, pred_format_func
 from sibylapp2.view.plots import charts
 from sibylapp2.view.utils import filtering, helpers
 from plotly.subplots import make_subplots
 
 
-def filter_contributions(to_show, sort_by, lead=0):
+def filter_contributions(to_show, sort_by, num_features=8):
     sort_columns = to_show.drop(columns="Feature").columns
     # filter by the contribution values at 0 lead
     if sort_by == "Absolute":
@@ -18,18 +18,18 @@ def filter_contributions(to_show, sort_by, lead=0):
         to_show = to_show.drop(columns="Average_Abs")
     if sort_by == f"Most {get_term('Positive')}":
         to_show["Average"] = to_show[sort_columns].mean(axis=1)
-        to_show = to_show.sort_values(by=lead, axis=0, ascending=False)
+        to_show = to_show.sort_values(by="Average", axis=0, ascending=False)
         to_show = to_show.drop(columns="Average")
     if sort_by == f"Most {get_term('Negative')}":
         to_show["Average"] = to_show[sort_columns].mean(axis=1)
-        to_show = to_show.sort_values(by=lead, axis=0, ascending=True)
+        to_show = to_show.sort_values(by="Average", axis=0, ascending=True)
         to_show = to_show.drop(columns="Average")
     if sort_by == "Greatest Change":
         to_show["Range"] = to_show[sort_columns].max(axis=1) - to_show[sort_columns].min(axis=1)
         to_show = to_show.sort_values(by="Range", axis=0, ascending=False)
         to_show = to_show.drop(columns="Range")
     to_show = filtering.process_options(to_show)
-    return to_show.iloc[0:MAX_FEATURES, :]
+    return to_show.iloc[0:num_features, :]
 
 
 def get_contributions_variation(
@@ -116,7 +116,7 @@ def plot_contributions_variation(eid, row_id, model_ids, fig=None):
         "Greatest Change",
     ])
     wide_df = get_contributions_variation(eid, row_id, model_ids)
-    wide_df = filter_contributions(wide_df, sort_by)
+    wide_df = filter_contributions(wide_df, sort_by, 10)
 
     fig = charts.plot_temporal_line_charts(wide_df, fig, secondary_y=True)
     return fig

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -105,9 +105,9 @@ def plot_prediction_variation(
     df = pd.DataFrame({"time": timeindex, "value": probs, "label": predictions})
 
     if st.session_state["display_proba"]:
-        fig = charts.plot_scatter_chart(df, fig, yaxis_range=[0, 1])
+        fig = charts.plot_prediction_regions(df, fig, yaxis_range=[0, 1])
     else:
-        fig = charts.plot_scatter_chart(df, fig)
+        fig = charts.plot_prediction_regions(df, fig)
     return fig
 
 

--- a/sibylapp2/view/temporal_change.py
+++ b/sibylapp2/view/temporal_change.py
@@ -45,20 +45,26 @@ def get_contributions_variation(
     """
     # store model predictions in the same order of the given models
     contributions_list = []
+    values_list = []
     feature_name = None
     for model_id in model_ids:
-        contribution_df, _ = contributions.get_contributions_for_rows(
+        contribution_df, value_df = contributions.get_contributions_for_rows(
             eid, [row_id], model_id=model_id
         )
         if feature_name is None:
             feature_name = contribution_df.columns
 
         contributions_list.append(contribution_df.iloc[0].rename(int(model_id[:-1])))
+        values_list.append(value_df.iloc[0].rename(int(model_id[:-1])))
     contributions_table = pd.concat(contributions_list, axis=1)
+    values_table = pd.concat(values_list, axis=1)
     feature_table = features.get_features()
     contributions_table = pd.concat([feature_table, contributions_table], axis=1)
+    values_table = pd.concat([feature_table["Feature"], values_table], axis=1).set_index(
+        "Feature", drop=True
+    )
 
-    return contributions_table
+    return contributions_table, values_table
 
 
 def plot_prediction_variation(
@@ -116,10 +122,10 @@ def plot_contributions_variation(eid, row_id, model_ids, fig=None):
         f"Most {get_term('Negative')}",
         "Greatest Change",
     ])
-    wide_df = get_contributions_variation(eid, row_id, model_ids)
+    wide_df, value_df = get_contributions_variation(eid, row_id, model_ids)
     wide_df = filter_contributions(wide_df, sort_by, 10)
 
-    fig = charts.plot_temporal_line_charts(wide_df, fig, secondary_y=True)
+    fig = charts.plot_temporal_line_charts(wide_df, value_df, fig, secondary_y=True)
     return fig
 
 

--- a/sibylapp2/view/utils/filtering.py
+++ b/sibylapp2/view/utils/filtering.py
@@ -162,7 +162,7 @@ def view_filtering(include_show_more=False):
         ("search_term" in st.session_state and len(st.session_state["search_term"]) > 0)
         or ("filters" in st.session_state and len(st.session_state["filters"]) > 0)
     )
-    exp = st.expander("Search and filter", expanded=expanded)
+    exp = st.expander("Search and filter", expanded=True)
 
     with exp:
         st.text_input(

--- a/sibylapp2/view/utils/filtering.py
+++ b/sibylapp2/view/utils/filtering.py
@@ -158,10 +158,6 @@ def view_filtering(include_show_more=False):
     else:
         st.session_state["show_more"] = True
 
-    expanded = bool(
-        ("search_term" in st.session_state and len(st.session_state["search_term"]) > 0)
-        or ("filters" in st.session_state and len(st.session_state["filters"]) > 0)
-    )
     exp = st.expander("Search and filter", expanded=True)
 
     with exp:


### PR DESCRIPTION
Based on feedback from users, this PR updates the change-over-time page to have a cleaner look. The predictions are now shown in a background bar plot, with feature lines being rendered in either red or blue depending on their absolute contribution. Sort order has also been updated to consider the feature values across the full time frame, and a "greatest change" option has been added. Finally, filtering by categories now works on this page.

Also making a small update to have the search-and-filter bar always expanded by default, to avoid it annoyingly disappearing when deleting filters