### PR TITLE
Fixing issue with how configs work

### DIFF
--- a/sibylapp2/config.py
+++ b/sibylapp2/config.py
@@ -4,7 +4,18 @@ from os import path
 import streamlit as st
 import yaml
 
-from sibylapp2.compute.context import get_config
+from sibylapp2.compute.context import get_config as get_api_config
+
+
+def get_from_config(key, default=None):
+    """
+    Returns a value from the config, or a default value if the key is not present or if
+    the value in the config is None.
+    """
+    cfg = load_config()
+    if key not in cfg or cfg[key] is None:
+        return default
+    return cfg[key]
 
 
 @st.cache_data(show_spinner=False)
@@ -16,24 +27,19 @@ def load_config():
 
 # GENERAL CONFIGURATIONS ==========================================================================
 def get_bar_length():
-    return load_config().get("BAR_LENGTH", 8)
+    return get_from_config("BAR_LENGTH", 8)
 
 
 def get_max_entities():
-    return load_config().get("MAX_ENTITIES", 11)
+    return get_from_config("MAX_ENTITIES", 11)
 
 
 def get_dataset_size():
-    return load_config().get("DATASET_SIZE", 1000)
+    return get_from_config("DATASET_SIZE", 1000)
 
 
 def get_load_upfront():
-    return load_config().get("LOAD_UPFRONT", True)
-
-
-def get_color_scheme():
-    flip_colors = load_config().get("FLIP_COLORS", False)
-    return load_config().get("COLOR_SCHEME", "Reversed" if flip_colors else "Standard")
+    return get_from_config("LOAD_UPFRONT", True)
 
 
 def get_pages_to_show():
@@ -42,10 +48,10 @@ def get_pages_to_show():
 
 # APPLICATION-SPECIFIC CONFIGURATIONS =============================================================
 def select_config(name, api_name, default):
-    if load_config().get(name) is not None:
-        return load_config().get(name)
-    if get_config(api_name) is not None:
-        return get_config(api_name)
+    if get_from_config(name) is not None:
+        return get_from_config(name)
+    if get_api_config(api_name) is not None:
+        return get_api_config(api_name)
     return default
 
 
@@ -82,7 +88,7 @@ ROW_LABEL = select_config("ROW_LABEL", "row_label", "Row")
 def pred_format_func(pred, display_proba=False):
     if display_proba:
         return f"{pred*100:.1f}%"
-    if load_config().get("OVERRIDE_PRED_FORMAT"):
+    if get_from_config("OVERRIDE_PRED_FORMAT"):
         return manual_pred_format_func(pred)
     if PREDICTION_TYPE == PredType.NUMERIC:
         return PRED_FORMAT_STRING.format(pred)
@@ -94,3 +100,7 @@ def pred_format_func(pred, display_proba=False):
 def manual_pred_format_func(pred):
     # Not used unless config.OVERRIDE_PRED_FORMAT == True
     return str(pred)
+
+
+def get_color_scheme():
+    return get_from_config("COLOR_SCHEME", "Reversed" if FLIP_COLORS else "Standard")

--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -20,6 +20,6 @@ SUPPORT_PROBABILITY: # Only set this to True when model supports `predict_proba`
 PAGES_TO_SHOW: # Set to a list of pages or "all" to show all pages
 ALLOW_PAGE_SELECTION:  # If true, allow user to select which pages to show (requires settings page)
 
-# TIME-SERIES-SPECIFIC CONFIGUREATIONS ============================================================
+# TIME-SERIES-SPECIFIC CONFIGURATIONS =============================================================
 MAX_FEATURES: 10 # Maximum number of features to show on time-series explanation plots
 TIME_UNIT: days # unit of time used in application and plots

--- a/sibylapp2/config.yml
+++ b/sibylapp2/config.yml
@@ -9,8 +9,8 @@ DATASET_SIZE: 1000 # Max number of entities to use for dataset-wide visualizatio
 LOAD_UPFRONT: true # If true, run heavy computations on initial load, else greedily run as needed
 
 # APPLICATION-SPECIFIC CONFIGURATIONS (overrides API context) =====================================
-FLIP_COLORS: false # deprecated (use COLOR_SCHEME) keeping for api support
-COLOR_SCHEME: Standard # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
+FLIP_COLORS: # deprecated (use COLOR_SCHEME) keeping for api support
+COLOR_SCHEME: # Standard: positive is blue. Reversed: positive is red. Neutral: Neither
 PREDICTION_TYPE: # One of "numeric", "boolean", "categorical"
 POSITIVE_TERM: # Term to use for a True prediction for boolean models
 NEGATIVE_TERM: # Term to use for a False prediction for boolean models


### PR DESCRIPTION
Removing manual configs that snuck in a previous PR, and fixing issues with config logic. Default configs will be correctly used when an entry exists for a given key in config.yml, but the value is None.

